### PR TITLE
fix: Add Python dispatcher for multi-ISA CPU support

### DIFF
--- a/docs/runtime-isa-dispatch.md
+++ b/docs/runtime-isa-dispatch.md
@@ -1,0 +1,1928 @@
+# Runtime ISA Dispatch for CPU Inference
+
+This document covers research on runtime Instruction Set Architecture (ISA) dispatch mechanisms, specifically how PyTorch, Intel Extension for PyTorch (IPEX), and oneDNN handle multi-ISA support in a single binary, and how this could potentially apply to vLLM-CPU.
+
+**Last Updated:** December 2025 (Updated with industry research on dispatch patterns)
+
+## Table of Contents
+
+1. [Background](#background)
+2. [PyTorch/IPEX Dispatch Architecture](#pytorchipex-dispatch-architecture)
+3. [oneDNN JIT Dispatch Details](#onednn-jit-dispatch-details)
+4. [GCC Function Multi-Versioning](#gcc-function-multi-versioning)
+5. [vLLM CPU Kernel Architecture](#vllm-cpu-kernel-architecture)
+6. [Upstream Unified Wheel Implementation](#upstream-unified-wheel-implementation)
+7. [Industry Dispatch Patterns Research](#industry-dispatch-patterns-research)
+8. [Unified Wheel Strategy Options](#unified-wheel-strategy-options)
+9. [Mitigation Strategies for AVX2 Base](#mitigation-strategies-for-avx2-base)
+10. [Implementation Recommendations](#implementation-recommendations)
+11. [References](#references)
+12. [AMD CPU Compatibility](#amd-cpu-compatibility)
+13. [Conclusion](#conclusion)
+14. [Appendix: Multi-ISA Unified Wheel Implementation Plan](#appendix-multi-isa-unified-wheel-implementation-plan)
+
+## Background
+
+Currently, vLLM-CPU publishes **5 separate wheel packages**, each compiled with different CPU instruction set extensions:
+
+| Package | AVX512 | VNNI | BF16 | AMX | Target CPUs |
+|---------|--------|------|------|-----|-------------|
+| `vllm-cpu` | - | - | - | - | All CPUs (base build) |
+| `vllm-cpu-avx512` | Yes | - | - | - | Intel Skylake-X+ |
+| `vllm-cpu-avx512vnni` | Yes | Yes | - | - | Intel Cascade Lake+ |
+| `vllm-cpu-avx512bf16` | Yes | Yes | Yes | - | Intel Cooper Lake+ |
+| `vllm-cpu-amxbf16` | Yes | Yes | Yes | Yes | Intel Sapphire Rapids+ |
+
+A single-wheel approach with runtime ISA detection could simplify installation but introduces complexity.
+
+## PyTorch/IPEX Dispatch Architecture
+
+### Dispatch Stub Pattern
+
+PyTorch uses a `DispatchStub` pattern (defined in `ATen/native/DispatchStub.h`) that enables runtime kernel selection:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Kernel Stub (virtual)                      │
+│         "my_kernel_stub(kCPU, tensor, ...)"                    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ Runtime CPUID check (first call)
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+        ▼                     ▼                     ▼
+   ┌─────────┐          ┌─────────┐          ┌─────────┐
+   │ DEFAULT │          │  AVX2   │          │ AVX512  │  ...
+   │ kernel  │          │ kernel  │          │ kernel  │
+   └─────────┘          └─────────┘          └─────────┘
+```
+
+### Build-time Code Generation
+
+The same source file is compiled multiple times with different compiler flags. IPEX's CodeGen process (in `cmake/cpu/IsaCodegen.cmake`) generates:
+
+```
+MyKernel.cpp
+    ├── MyKernel.cpp.DEFAULT.cpp  (-mavx2)
+    ├── MyKernel.cpp.AVX2.cpp     (-mavx2 -mfma)
+    ├── MyKernel.cpp.AVX512.cpp   (-mavx512f -mavx512bw -mavx512vl -mavx512dq)
+    ├── MyKernel.cpp.AVX512_VNNI.cpp  (-mavx512vnni ...)
+    ├── MyKernel.cpp.AVX512_BF16.cpp  (-mavx512bf16 ...)
+    ├── MyKernel.cpp.AMX.cpp      (-mamx-tile -mamx-int8 -mamx-bf16 ...)
+    └── MyKernel.cpp.AVX512_FP16.cpp  (-mavx512fp16 ...)
+```
+
+Each generated object file contains its function body in an **anonymous namespace** to prevent symbol conflicts.
+
+### ISA Level Support
+
+| ISA Level | PyTorch | IPEX 2.x | GCC Required |
+|-----------|---------|----------|--------------|
+| DEFAULT   | Yes | No (uses AVX2) | Any |
+| AVX2      | Yes | Yes | Any |
+| AVX2_VNNI | No  | Yes | GCC 11.2+ |
+| AVX512    | Yes | Yes | GCC 9.2+ |
+| AVX512_VNNI | No | Yes | GCC 9.2+ |
+| AVX512_BF16 | No | Yes | GCC 10.3+ |
+| AMX       | No  | Yes | GCC 11.2+ |
+| AVX512_FP16 | No | Yes | GCC 12.1+ |
+
+### Implementation Pattern
+
+**Header file** - Declare the dispatch stub:
+```cpp
+// MyKernel.h
+#include <dyndisp/DispatchStub.h>
+
+using my_kernel_fn = void (*)(const Tensor&, const Tensor&);
+IPEX_DECLARE_DISPATCH(my_kernel_fn, my_kernel_stub);
+```
+
+**Source file** - Define the stub:
+```cpp
+// MyKernel.cpp
+#include "MyKernel.h"
+
+IPEX_DEFINE_DISPATCH(my_kernel_stub);
+
+void my_kernel(const Tensor& a, const Tensor& b) {
+  return my_kernel_stub(kCPU, a, b);
+}
+```
+
+**Kernel implementation** - Register ISA-specific versions:
+```cpp
+// kernels/MyKernelKrnl.cpp
+#include "MyKernel.h"
+
+namespace {
+// Anonymous namespace prevents symbol conflicts between ISA versions
+
+#if defined(CPU_CAPABILITY_AVX512_BF16)
+void kernel_impl(const Tensor& a, const Tensor& b) {
+  // Use native BF16 instructions
+  // _mm512_cvtneps_pbh(...)
+}
+#elif defined(CPU_CAPABILITY_AVX512)
+void kernel_impl(const Tensor& a, const Tensor& b) {
+  // AVX512 implementation
+}
+#else
+void kernel_impl(const Tensor& a, const Tensor& b) {
+  // Scalar/AVX2 fallback
+}
+#endif
+
+} // anonymous namespace
+
+IPEX_REGISTER_DISPATCH(my_kernel_stub, &kernel_impl);
+```
+
+### Runtime Selection
+
+- CPU features are detected via CPUID on first kernel call
+- Function pointer is cached for subsequent calls
+- Can be overridden via environment variable:
+  ```bash
+  ATEN_CPU_CAPABILITY=avx2 python script.py
+  ```
+
+### Debug APIs (IPEX)
+
+```python
+import intel_extension_for_pytorch._C as core
+
+# Query current effective ISA level
+core._get_current_isa_level()  # e.g., 'AMX'
+
+# Query max CPU-supported ISA level
+core._get_highest_cpu_support_isa_level()
+
+# Query max binary-supported ISA level
+core._get_highest_binary_support_isa_level()
+```
+
+## oneDNN JIT Dispatch Details
+
+oneDNN (Intel's oneAPI Deep Neural Network Library) uses Just-In-Time compilation to generate ISA-specific kernels at runtime.
+
+### How oneDNN JIT Works
+
+1. **Runtime ISA Detection**: On first use, oneDNN detects CPU features via CPUID
+2. **JIT Code Generation**: Kernels are generated optimized for the detected ISA
+3. **Primitive Caching**: Generated kernels are cached to avoid re-compilation
+4. **Automatic Dispatch**: Best implementation selected without user intervention
+
+### Supported ISA Levels (oneDNN 3.x)
+
+| Environment Variable Value | Description |
+|---------------------------|-------------|
+| `SSE41` | Intel SSE4.1 |
+| `AVX` | Intel AVX |
+| `AVX2` | Intel AVX2 |
+| `AVX2_VNNI` | Intel AVX2 with DL Boost |
+| `AVX512_CORE` | Intel AVX-512 (F, BW, VL, DQ) |
+| `AVX512_CORE_VNNI` | Intel AVX-512 with DL Boost |
+| `AVX512_CORE_BF16` | Intel AVX-512 with BF16 |
+| `AVX10_1_512` | Intel AVX10.1/512 with FP16 |
+| `AVX10_1_512_AMX` | Intel AVX10.1/512 with AMX |
+| `AVX10_1_512_AMX_FP16` | Intel AVX10.1/512 with AMX FP16 |
+| `DEFAULT` | No ISA restrictions (recommended) |
+
+### Key Environment Variables
+
+```bash
+# Show verbose JIT info (essential for debugging)
+ONEDNN_VERBOSE=1
+
+# Control max ISA level (set to ALL or DEFAULT for full auto-detection)
+ONEDNN_MAX_CPU_ISA=DEFAULT
+
+# Primitive cache capacity (0 disables caching)
+ONEDNN_PRIMITIVE_CACHE_CAPACITY=1024
+
+# Build-time CMake flag (CRITICAL for unified wheel)
+-DDNNL_MAX_CPU_ISA=ALL
+```
+
+### Primitive Cache
+
+oneDNN caches JIT-compiled kernels to avoid recompilation:
+
+```cpp
+// First call: JIT compilation happens
+auto matmul_prim = matmul(matmul_pd);  // ~5-50ms
+
+// Subsequent calls: cached, near-zero overhead
+matmul_prim.execute(stream, args);
+```
+
+**Verification:**
+```python
+import os
+os.environ['ONEDNN_VERBOSE'] = '1'
+import torch  # or vllm
+
+# Look for ISA indicators in output:
+# onednn_verbose,exec,cpu,matmul,... avx512_core_amx ...
+```
+
+## GCC Function Multi-Versioning
+
+GCC supports `target_clones` attribute for automatic function multi-versioning.
+
+### Basic Usage
+
+```cpp
+__attribute__((target_clones("default","avx2","avx512f","avx512bw")))
+void process_data(float* data, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        data[i] = data[i] * 2.0f;
+    }
+}
+```
+
+**What the compiler generates:**
+1. `process_data.default` - baseline implementation
+2. `process_data.avx2` - AVX2-optimized version
+3. `process_data.avx512f` - AVX512 version
+4. `process_data.avx512bw` - AVX512BW version
+5. `process_data.resolver` - GNU ifunc resolver
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    process_data (ifunc)                         │
+│              Resolved ONCE at program load time                 │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ __cpu_indicator_init() + CPUID
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+        ▼                     ▼                     ▼
+   ┌──────────┐         ┌──────────┐         ┌───────────┐
+   │ .default │         │  .avx2   │         │ .avx512f  │
+   └──────────┘         └──────────┘         └───────────┘
+```
+
+### Micro-architecture Levels (GCC 12+)
+
+```cpp
+__attribute__((target_clones("default","arch=x86-64-v2","arch=x86-64-v3","arch=x86-64-v4")))
+void compute(float* a, float* b, float* c, int n);
+```
+
+| Level | Features |
+|-------|----------|
+| x86-64 | SSE2 (baseline) |
+| x86-64-v2 | SSE4.2, POPCNT, CX16 |
+| x86-64-v3 | AVX2, FMA, BMI2 |
+| x86-64-v4 | AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL |
+
+### Drawbacks
+
+1. **No inlining across ifunc**: Functions using ifunc cannot be inlined
+2. **Resolver overhead**: Small one-time cost at program start
+3. **Binary size increase**: ~N× for N versions of each function
+4. **Template limitations**: GCC requires target_clones on template instantiations
+
+## vLLM CPU Kernel Architecture
+
+### Compute Distribution (from vLLM maintainer analysis)
+
+On a 32-core x86 AMX platform running Llama3-8B:
+
+| Operation | Time % | Optimization Strategy |
+|-----------|--------|----------------------|
+| **Linear layers (nn.linear)** | ~60% | oneDNN handles automatically |
+| **Paged Attention** | ~25% | Custom C++ kernel with intrinsics |
+| **Other operations** | ~15% | PyTorch/element-wise ops |
+
+**Key Insight:** Without AMX accelerator, linear layers consume even more time, making oneDNN JIT optimization even more critical.
+
+### oneDNN Coverage in vLLM
+
+vLLM CPU backend uses oneDNN for:
+- `nn.linear` operations (default)
+- INT8 GEMM kernels (quantized models)
+- Matmul operations via PyTorch
+
+### Custom Kernels (outside oneDNN)
+
+Located in `csrc/cpu/`:
+- `paged_attention_v1` / `paged_attention_v2`
+- Memory-bound operations (less ISA-sensitive)
+- Custom quantization kernels
+
+## Upstream Unified Wheel Implementation
+
+As of December 2025, the upstream vLLM project builds a **unified CPU wheel** with runtime ISA dispatch. This section documents how their implementation works.
+
+**Source:** [vllm-project/vllm/.buildkite/release-pipeline.yaml](https://github.com/vllm-project/vllm/blob/main/.buildkite/release-pipeline.yaml)
+
+### Build Configuration
+
+The upstream x86 CPU wheel is built with ALL ISA extensions enabled simultaneously:
+
+```yaml
+# .buildkite/release-pipeline.yaml (line ~150)
+- label: "Build x86 CPU wheel"
+  commands:
+    - "docker build \
+        --build-arg VLLM_CPU_AVX512BF16=true \
+        --build-arg VLLM_CPU_AVX512VNNI=true \
+        --build-arg VLLM_CPU_AMXBF16=true \
+        -f docker/Dockerfile.cpu ."
+```
+
+This compiles ALL ISA-specific implementations into a single wheel:
+- VEC (AVX2/AVX512 vectorized)
+- VEC16 (16-wide vectors)
+- AMX (Intel Advanced Matrix Extensions)
+- NEON (ARM, separate wheel)
+
+### Compile-Time: All Implementations Included
+
+The C++ code uses preprocessor conditionals to include ISA-specific implementations when the corresponding build flag is set:
+
+```cpp
+// csrc/cpu/cpu_attn.cpp
+
+#ifdef CPU_CAPABILITY_AMXBF16
+  #include "cpu_attn_amx.hpp"
+  #define AMX_DISPATCH(...)                                                   \
+    case cpu_attention::ISA::AMX: {                                           \
+      using attn_impl = cpu_attention::AttentionImpl<cpu_attention::ISA::AMX, \
+                                                     scalar_t, head_dim>;     \
+      return __VA_ARGS__();                                                   \
+    }
+#else
+  #define AMX_DISPATCH(...) case cpu_attention::ISA::AMX:  // Empty fallback
+#endif
+
+#ifdef __aarch64__
+  #include "cpu_attn_neon.hpp"
+  #define NEON_DISPATCH(...)                                                   \
+    case cpu_attention::ISA::NEON: {                                           \
+      using attn_impl = cpu_attention::AttentionImpl<cpu_attention::ISA::NEON, \
+                                                     scalar_t, head_dim>;      \
+      return __VA_ARGS__();                                                    \
+    }
+#else
+  #define NEON_DISPATCH(...) case cpu_attention::ISA::NEON:
+#endif
+```
+
+### Runtime Detection: Python-Side ISA Selection
+
+At runtime, Python detects CPU capabilities using PyTorch's built-in functions and selects the appropriate ISA:
+
+```python
+# vllm/v1/attention/backends/cpu_attn.py
+
+def _get_attn_isa(dtype: torch.dtype, block_size: int) -> str:
+    supports_amx = torch._C._cpu._is_amx_tile_supported()
+
+    if supports_amx and dtype in (torch.bfloat16,) and block_size % 32 == 0:
+        return "amx"
+    elif block_size % 32 == 0:
+        if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
+            return "neon"
+        else:
+            return "vec"   # AVX2/AVX512 vectorized
+    else:
+        return "vec16"     # Smaller vector width
+```
+
+Key detection functions:
+- `torch._C._cpu._is_amx_tile_supported()` - Checks for AMX support via CPUID
+- `current_platform.get_cpu_architecture()` - Detects ARM vs x86
+
+### Runtime Dispatch: C++ Switch Statement
+
+The ISA string from Python is passed to C++ which dispatches to the correct implementation:
+
+```cpp
+// csrc/cpu/cpu_attn.cpp
+
+cpu_attention::ISA isa_tag = [&]() {
+    if (isa == "amx") {
+        return cpu_attention::ISA::AMX;
+    } else if (isa == "vec") {
+        return cpu_attention::ISA::VEC;
+    } else if (isa == "vec16") {
+        return cpu_attention::ISA::VEC16;
+    } else if (isa == "neon") {
+        return cpu_attention::ISA::NEON;
+    } else {
+        TORCH_CHECK(false, "Invalid ISA type: " + isa);
+    }
+}();
+
+// Dispatch macro switches to correct implementation
+#define CPU_ATTN_DISPATCH_IMPL(ISA_TYPE, ...)                                 \
+  [&] {                                                                       \
+    switch (ISA_TYPE) {                                                       \
+      AMX_DISPATCH(__VA_ARGS__)                                               \
+      NEON_DISPATCH(__VA_ARGS__)                                              \
+      case cpu_attention::ISA::VEC: { ... }                                   \
+      case cpu_attention::ISA::VEC16: { ... }                                 \
+    }                                                                         \
+  }()
+```
+
+### Dispatch Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        Unified vLLM-CPU Wheel                            │
+│  Contains: VEC, VEC16, AMX implementations (all compiled in)            │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Python: _get_attn_isa()                              │
+│  torch._C._cpu._is_amx_tile_supported() → CPUID detection               │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                    ┌───────────────┼───────────────┐
+                    │               │               │
+                    ▼               ▼               ▼
+              isa="amx"       isa="vec"       isa="vec16"
+                    │               │               │
+                    └───────────────┼───────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    C++: CPU_ATTN_DISPATCH_IMPL()                        │
+│  switch(isa_tag) → AMX_DISPATCH / VEC / VEC16                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### ARM64 Handling
+
+ARM64 is built as a **separate wheel** with different optimizations:
+
+```yaml
+# .buildkite/release-pipeline.yaml
+- label: "Build arm64 CPU wheel"
+  commands:
+    - "docker build \
+        --build-arg VLLM_BUILD_ACL=ON \
+        -f docker/Dockerfile.cpu ."
+```
+
+| Platform | Build Flags | Runtime Dispatch |
+|----------|-------------|------------------|
+| **x86_64** | `AVX512BF16=true`, `AVX512VNNI=true`, `AMXBF16=true` | AMX → VEC → VEC16 |
+| **ARM64** | `VLLM_BUILD_ACL=ON` | NEON only |
+
+ARM64 uses:
+- **ARM Compute Library (ACL)** - Provides optimized GEMM kernels
+- **oneDNN with ACL backend** - For matrix operations
+- **NEON intrinsics** - For custom attention kernels
+
+### Upstream Wheel Summary
+
+| Aspect | x86_64 Wheel | ARM64 Wheel |
+|--------|--------------|-------------|
+| **ISA Implementations** | VEC, VEC16, AMX | NEON |
+| **oneDNN Backend** | Native x86 | ACL |
+| **Runtime Detection** | `_is_amx_tile_supported()` | Architecture check |
+| **Dispatch Mechanism** | ISA string → C++ switch | Fixed NEON |
+| **Fallback** | VEC16 (always works) | N/A |
+
+### Critical Limitation: AVX512 Minimum Required
+
+**IMPORTANT:** The upstream unified wheel requires **AVX512 as the minimum baseline**. It does NOT support AVX2-only CPUs.
+
+#### Why AVX2 CPUs Are Not Supported
+
+1. **CMake ISA Selection is Mutually Exclusive:**
+   ```cmake
+   if (AVX512_FOUND AND NOT AVX512_DISABLED)
+       list(APPEND CXX_COMPILE_FLAGS "-mavx512f" ...)  # ← Upstream uses this path
+   elseif (AVX2_FOUND)
+       list(APPEND CXX_COMPILE_FLAGS "-mavx2")         # ← Never reached
+   ```
+
+2. **C++ Vector Types Are Compile-Time:**
+   ```cpp
+   // csrc/cpu/cpu_types_x86.hpp
+   #ifdef __AVX512F__
+   struct BF16Vec32 { __m512i reg; };     // ← Only this is compiled
+   #else
+   struct BF16Vec32 { __m256i reg_low, reg_high; };  // ← Never compiled
+   #endif
+   ```
+
+3. **Runtime Dispatch Assumes AVX512:**
+   - `"amx"` → AMX instructions (AVX512 required)
+   - `"vec"` → AVX512 vectorized (not AVX2!)
+   - `"vec16"` → 16-wide AVX512 vectors
+
+#### CPUs That Work vs Don't Work
+
+| CPU | Works with Upstream Wheel | Notes |
+|-----|---------------------------|-------|
+| Intel Skylake-X+ | ✅ Yes | Has AVX512 |
+| Intel Cascade Lake+ | ✅ Yes | Has AVX512 + VNNI |
+| Intel Sapphire Rapids+ | ✅ Yes | Has AVX512 + AMX |
+| AMD EPYC Genoa (Zen 4) | ✅ Yes | Has AVX512 + BF16 |
+| Intel Haswell/Broadwell | ❌ No | AVX2 only |
+| AMD EPYC Milan (Zen 3) | ❌ No | AVX2 only |
+| Intel Core i7-8xxx | ❌ No | AVX2 only |
+
+### Implications for This Project
+
+The upstream unified wheel approach means:
+
+1. **Our 5-wheel approach provides BROADER compatibility** - Our `vllm-cpu` (noavx512) variant supports AVX2-only CPUs that upstream cannot
+2. **Runtime dispatch is proven** - The AMX/VEC/VEC16 dispatch mechanism works in production
+3. **oneDNN JIT still applies** - Linear layers (60%+ of compute) use oneDNN JIT regardless
+4. **Our noavx512 wheel serves a gap** - CPUs without AVX512 need our base wheel
+
+**Comparison:**
+```
+Upstream:  1 x86 wheel (AVX512 minimum) + 1 ARM64 wheel = 2 wheels
+           ❌ Older CPUs unsupported
+
+Ours:      5 x86 wheels + 1 ARM64 wheel = 6 wheels
+           ✅ AVX2-only CPUs supported via vllm-cpu (noavx512)
+```
+
+We should NOT blindly adopt upstream's approach if we want to support older CPUs.
+
+## Industry Dispatch Patterns Research
+
+This section documents how major open-source projects handle runtime ISA dispatch, based on comprehensive research of battle-tested implementations.
+
+### Key Finding: Single Binary with Runtime Dispatch
+
+**Every major project uses a single binary with runtime dispatch.** The patterns below are battle-tested in production.
+
+### Pattern 1: OpenBLAS - Function Pointer Arrays
+
+OpenBLAS uses `DYNAMIC_ARCH=1` to compile multiple CPU targets into one library:
+
+```c
+// Pseudocode from OpenBLAS architecture
+static blas_function_table kernels[NUM_ARCHITECTURES];
+
+void initialize_openblas() {
+    int detected_arch = get_cpu_architecture();  // CPUID detection
+    current_kernels = &kernels[detected_arch];
+}
+
+void cblas_dgemm(...) {
+    current_kernels->dgemm(...);  // Indirect call through function pointer
+}
+```
+
+**Characteristics:**
+- Single .so file with all architecture variants
+- Function pointer tables select kernels at initialization
+- Automatic fallback to closest compatible CPU
+- Used by NumPy, SciPy (battle-tested)
+- One-time initialization overhead (~microseconds)
+
+### Pattern 2: FFmpeg - Function Pointers + target Attribute
+
+```c
+// FFmpeg pattern
+void (*ff_memchr)(const char*, size_t, char);
+
+static void memchr_sse2(const char* data, size_t size, char c)
+    __attribute__((target("sse2"))) { ... }
+
+static void memchr_avx2(const char* data, size_t size, char c)
+    __attribute__((target("avx2"))) { ... }
+
+void ff_init_cpu() {
+    int cpu_flags = av_get_cpu_flags();  // CPUID detection
+
+    if (cpu_flags & AV_CPU_FLAG_AVX2)
+        ff_memchr = memchr_avx2;
+    else if (cpu_flags & AV_CPU_FLAG_SSE2)
+        ff_memchr = memchr_sse2;
+    else
+        ff_memchr = memchr_scalar;
+}
+```
+
+**Characteristics:**
+- All variants compiled into same binary with `__attribute__((target(...)))`
+- Function pointers initialized once at startup
+- Clean, maintainable code pattern
+- 1-2ns indirect call overhead (negligible for ML workloads)
+
+### Pattern 3: glibc - GNU IFUNC (Zero Overhead)
+
+```c
+// glibc pattern for memchr, strcmp, etc.
+static void* memchr_resolver(void) {
+    __cpu_indicator_init();
+
+    if (__cpu_features2 & FEATURE_AVX512)
+        return memchr_avx512;
+    if (__cpu_features2 & FEATURE_AVX2)
+        return memchr_avx2;
+    return memchr_generic;
+}
+
+void* memchr(const void*, int, size_t)
+    __attribute__((ifunc("memchr_resolver")));
+```
+
+**Characteristics:**
+- IFUNC called **once by dynamic linker** during program load
+- After resolution, calls are **direct** (no indirection)
+- **Zero runtime overhead** after initialization
+- Linux/glibc-specific (not portable)
+- Resolver runs early (can't call external libraries)
+
+### Pattern 4: Modern GCC/Clang - target_clones (Recommended)
+
+The cleanest modern approach (GCC 6+, Clang 7+):
+
+```cpp
+__attribute__((target_clones("default", "avx2", "avx512f", "avx512f,avx512bw,avx512vl")))
+void process_batch(const float* input, float* output, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        output[i] = input[i] * 2.0f;
+    }
+}
+```
+
+Compiler automatically generates:
+- `process_batch.default`
+- `process_batch.avx2`
+- `process_batch.avx512f`
+- `process_batch.avx512f_avx512bw_avx512vl`
+- IFUNC resolver that picks best version at runtime
+
+**Characteristics:**
+- Cleanest code - single source, compiler handles everything
+- Uses IFUNC under the hood (zero overhead after resolution)
+- Works with templates and complex C++
+- Binary size increases ~N× for N variants
+
+### Performance Comparison
+
+| Approach | Init Overhead | Per-Call Overhead | Binary Size |
+|----------|--------------|-------------------|-------------|
+| Function pointers | ~1μs | ~1-2ns | N × base |
+| IFUNC / target_clones | ~100μs (linker) | **0ns** | N × base |
+| Separate wheels | 0 | 0 | 1 × base each |
+
+### Benchmark Data (from Magnum Graphics blog)
+
+Real-world measurements for ISA-specific implementations:
+
+| Instruction Set | Time (ns) | Speedup vs Base |
+|-----------------|-----------|-----------------|
+| Scalar (no SIMD) | 95 | 1.0× |
+| AVX | 40 | 2.4× |
+| AVX2 | 30 | 3.2× |
+| AVX512 | 18 | 5.3× |
+
+The 1-2ns function pointer overhead is negligible compared to 18-95ns kernel execution time.
+
+### Industry Consensus
+
+Based on research of OpenBLAS, FFmpeg, glibc, oneDNN, and Intel MKL:
+
+1. **All use single binary** with multiple ISA implementations compiled in
+2. **Runtime dispatch via function pointers or IFUNC** - never dlopen
+3. **Separate wheels/packages** is a valid alternative (simpler, what we do)
+4. **IPEX-style multi-compilation** is the gold standard for performance-critical code
+
+## Unified Wheel Strategy Options
+
+Based on industry research, here are the viable approaches ranked by practicality:
+
+### Option 1: Keep Separate Wheels (Current - Validated)
+
+Our current 5-wheel approach is **validated by industry research** as a legitimate strategy:
+
+```
+vllm-cpu           → AVX2 base (broadest compatibility)
+vllm-cpu-avx512    → AVX512 optimized
+vllm-cpu-avx512vnni → AVX512 + VNNI
+vllm-cpu-avx512bf16 → AVX512 + BF16
+vllm-cpu-amxbf16    → AVX512 + AMX
+```
+
+**Pros:**
+- Zero runtime overhead (no dispatch)
+- Explicit ISA guarantee
+- Simple build system
+- No binary size increase
+- Broadest CPU support (AVX2 included)
+
+**Cons:**
+- 5× testing/publishing burden
+- Users must choose correct package
+
+**Verdict:** ✅ Recommended for maximum compatibility and simplicity.
+
+### Option 2: GCC target_clones (Best for True Unified Wheel)
+
+If we want a truly unified wheel supporting AVX2 through AMX, use GCC's function multi-versioning:
+
+```cpp
+// Apply to hot kernel functions
+__attribute__((target_clones("default", "avx2", "avx512f", "avx512f,avx512bw,avx512vl,avx512bf16")))
+void paged_attention_kernel(const float* q, const float* k, const float* v,
+                            float* output, int head_dim, int seq_len) {
+    // Single implementation - compiler generates ISA-specific versions
+    for (int i = 0; i < seq_len; i++) {
+        // Vectorizable loop - compiler auto-vectorizes per ISA
+    }
+}
+```
+
+**Implementation Steps:**
+1. Identify hot kernels in `csrc/cpu/` (~10-15 functions)
+2. Add `target_clones` attribute to each
+3. Ensure GCC 6+ or Clang 7+ in build
+4. Test on AVX2, AVX512, and AMX systems
+
+**Pros:**
+- Cleanest code (single source)
+- Zero runtime overhead (IFUNC)
+- Compiler handles optimization
+- Single wheel for all x86 CPUs
+
+**Cons:**
+- Binary size increases ~3-4×
+- Requires upstream vLLM changes
+- Linux-only (IFUNC not portable)
+
+**Effort:** Medium (~1-2 weeks for vLLM kernel modifications)
+
+### Option 3: AVX2 Base + oneDNN JIT (Partial Solution)
+
+Build vLLM with AVX2 as the base, let oneDNN handle ISA-specific optimization:
+
+```cmake
+# CMake configuration
+-DDNNL_MAX_CPU_ISA=ALL        # Allow all ISA levels
+-DONEDNN_BUILD_GRAPH=ON       # Enable graph API
+```
+
+**Wheel Size:** ~50-60MB (same as current single-variant)
+
+**Coverage:**
+- Linear layers (60%): Fully optimized via oneDNN JIT
+- Paged attention (25%): AVX2 only (acceptable for memory-bound ops)
+- Other ops (15%): AVX2 + PyTorch vectorization
+
+### Option 2: AVX2 Base + Selective DispatchStub
+
+Apply IPEX-style dispatch to hot kernels only:
+
+```
+vLLM Kernel
+    │
+    ├── oneDNN operations ──────────► oneDNN JIT (automatic)
+    │
+    ├── paged_attention ────────────► DispatchStub (5 ISA variants)
+    │
+    └── other custom kernels ───────► AVX2 base (acceptable)
+```
+
+**Wheel Size:** ~70-80MB (~30% increase)
+
+### Option 3: Full DispatchStub (Maximum Performance)
+
+Implement IPEX-style dispatch for ALL custom kernels:
+
+**Wheel Size:** ~250-300MB (~5× increase)
+
+### Option 4: torch.compile + IPEX Backend
+
+Use PyTorch 2.x compilation with Intel optimizations:
+
+```python
+import intel_extension_for_pytorch as ipex
+import torch
+
+model = ipex.optimize(model)
+model = torch.compile(model, backend="ipex")
+```
+
+**Benefits:**
+- Automatic kernel fusion
+- Vectorization with ISA detection
+- 1.2-1.7× speedup over eager mode
+
+### Trade-offs Summary
+
+| Approach | Binary Size | Build Complexity | Performance | Maintenance | Verdict |
+|----------|-------------|------------------|-------------|-------------|---------|
+| Separate wheels (current) | 50MB each | Low | Optimal | 5× testing | ✅ Validated |
+| GCC target_clones | ~150-200MB | Medium | Optimal | Low | ✅ Best unified |
+| AVX2 + oneDNN JIT | ~50MB | Low | 90-95% | Low | ⚠️ Partial |
+| IPEX DispatchStub | ~250MB | High | 100% | High | ⚠️ Complex |
+
+## Mitigation Strategies for AVX2 Base
+
+### Layer 1: Ensure oneDNN JIT is Unrestricted
+
+**CRITICAL:** Build with `DNNL_MAX_CPU_ISA=ALL`:
+
+```cmake
+# In CMakeLists.txt
+set(DNNL_MAX_CPU_ISA "ALL" CACHE STRING "Allow all ISA levels")
+```
+
+**Runtime verification:**
+```bash
+ONEDNN_VERBOSE=1 python -c "import vllm; ..." 2>&1 | grep -E "avx512|amx"
+```
+
+### Layer 2: PyTorch Inductor Optimization
+
+PyTorch 2.x Inductor C++/OpenMP backend provides:
+- Automatic vectorization (AVX2/AVX512)
+- oneDNN integration for Conv/GEMM
+- Explicit SIMD codegen for element-wise ops
+
+```python
+# Enable Inductor with CPU optimizations
+import torch
+model = torch.compile(model, backend="inductor")
+```
+
+### Layer 3: Selective DispatchStub for Hot Kernels
+
+For paged_attention and other critical custom kernels:
+
+```cpp
+// csrc/cpu/paged_attention.h
+IPEX_DECLARE_DISPATCH(paged_attention_fn, paged_attention_stub);
+
+// csrc/cpu/kernels/paged_attention_kernel.cpp
+namespace {
+#if defined(CPU_CAPABILITY_AMX)
+void paged_attention_impl(...) { /* AMX optimized */ }
+#elif defined(CPU_CAPABILITY_AVX512_BF16)
+void paged_attention_impl(...) { /* AVX512 BF16 */ }
+#elif defined(CPU_CAPABILITY_AVX512)
+void paged_attention_impl(...) { /* AVX512 */ }
+#else
+void paged_attention_impl(...) { /* AVX2 fallback */ }
+#endif
+}
+IPEX_REGISTER_DISPATCH(paged_attention_stub, &paged_attention_impl);
+```
+
+### Layer 4: GCC FMV for Standalone Functions
+
+For isolated utility functions:
+
+```cpp
+__attribute__((target_clones("default","avx2","avx512f")))
+void preprocess_tokens(int* tokens, size_t n) {
+    // Compiler generates optimized versions automatically
+}
+```
+
+### Environment Variables for Runtime Control
+
+```bash
+# oneDNN ISA control
+export ONEDNN_MAX_CPU_ISA=DEFAULT    # Auto-detect best ISA
+
+# PyTorch/IPEX ISA override (for testing)
+export ATEN_CPU_CAPABILITY=avx512    # Force specific level
+
+# Performance tuning
+export OMP_NUM_THREADS=32            # OpenMP threads
+export KMP_AFFINITY=granularity=fine,compact,1,0
+```
+
+## Implementation Recommendations
+
+### Phase 1: Quick Win (Minimal Changes)
+
+1. **Verify oneDNN JIT is enabled:**
+   ```bash
+   ONEDNN_VERBOSE=1 python -c "
+   import os
+   os.environ['VLLM_TARGET_DEVICE'] = 'cpu'
+   from vllm import LLM
+   llm = LLM(model='facebook/opt-125m', device='cpu')
+   llm.generate('Hello')
+   " 2>&1 | grep -i "avx512\|amx"
+   ```
+
+2. **Ensure build flags:**
+   ```cmake
+   -DDNNL_MAX_CPU_ISA=ALL
+   -DONEDNN_ENABLE_MAX_CPU_ISA=ON
+   ```
+
+3. **Expected result:** 90-95% of optimal performance with no code changes
+
+### Phase 2: torch.compile Integration
+
+```python
+import torch
+import intel_extension_for_pytorch as ipex
+
+# Optimize model
+model = ipex.optimize(model, dtype=torch.bfloat16)
+
+# Compile with IPEX backend
+model = torch.compile(model, backend="ipex")
+```
+
+### Phase 3: Custom Kernel Dispatch (If Needed)
+
+Only implement if benchmarks show >10% gap:
+
+1. Identify hot kernels via profiling
+2. Implement DispatchStub for those kernels only
+3. Test on multiple ISA levels
+4. Document fallback behavior
+
+### Benchmarking Protocol
+
+```bash
+# Test on different ISA levels
+for isa in avx2 avx512 avx512_core_amx; do
+    ONEDNN_MAX_CPU_ISA=$isa python benchmark.py --model llama-7b
+done
+
+# Compare against ISA-specific wheel
+pip install vllm-cpu-amxbf16
+python benchmark.py --model llama-7b  # Baseline
+```
+
+## References
+
+### Official Documentation
+- [oneDNN CPU Dispatcher Control](https://uxlfoundation.github.io/oneDNN/dev_guide_cpu_dispatcher_control.html)
+- [Intel Extension for PyTorch - ISA Dynamic Dispatch](https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/features/isa_dynamic_dispatch.html)
+- [PyTorch DispatchStub.h](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/DispatchStub.h)
+- [PyTorch Inductor CPU Inference](https://pytorch.org/blog/accelerated-cpu-inference/)
+
+### GCC Documentation
+- [GCC Function Multi-Versioning](https://gcc.gnu.org/wiki/FunctionMultiVersioning)
+- [MaskRay's FMV Deep Dive](https://maskray.me/blog/2023-02-05-function-multi-versioning)
+
+### vLLM Resources
+- [vLLM CPU Backend Discussion #10694](https://github.com/vllm-project/vllm/discussions/10694)
+- [vLLM AVX2 Support Issue #6178](https://github.com/vllm-project/vllm/issues/6178)
+- [vLLM CPU Installation Guide](https://docs.vllm.ai/en/stable/getting_started/installation/cpu/)
+- [vLLM Release Pipeline (CPU wheel build)](https://github.com/vllm-project/vllm/blob/main/.buildkite/release-pipeline.yaml) - Upstream unified wheel build configuration
+- [vLLM CPU Attention Backend](https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/cpu_attn.py) - Runtime ISA detection
+- [vLLM CPU Attention C++ Implementation](https://github.com/vllm-project/vllm/blob/main/csrc/cpu/cpu_attn.cpp) - ISA dispatch mechanism
+
+### Industry Dispatch Pattern Research
+- [OpenBLAS DYNAMIC_ARCH](https://github.com/OpenMathLib/OpenBLAS/wiki/Home) - Function pointer dispatch pattern
+- [Magnum Graphics - CPU Feature Detection](https://blog.magnum.graphics/backstage/cpu-feature-detection-dispatch/) - Comprehensive dispatch comparison
+- [MaskRay - GNU IFUNC](https://maskray.me/blog/2021-01-18-gnu-indirect-function) - Deep dive on IFUNC resolver
+- [CPU Instruction Set Dispatcher Example](https://mklimenko.github.io/english/2020/03/09/auto-instruction-set/) - Benchmark data for ISA dispatch
+
+### Related Projects
+- [vllm-AVX2-cpu-optimized](https://github.com/SaroM0/vllm-AVX2-cpu-optimized) - Community AVX2 build
+
+## AMD CPU Compatibility
+
+### oneDNN Uses CPUID-Based Detection (Not Vendor Detection)
+
+A critical advantage of the oneDNN JIT approach is that it works identically on AMD and Intel CPUs. From the official oneDNN GitHub Issue #1056:
+
+> "On x86-64 platforms oneDNN detects processor instruction set (ISA) using `cpuid` instruction at runtime and dispatches the best available codepath based on this information. An AMD processor with Intel AVX2 instruction set support will run Intel AVX2 codepath."
+
+### AMD EPYC AVX512BF16 Support
+
+| AMD Processor | Architecture | AVX512BF16 | oneDNN ISA Level |
+|---------------|--------------|------------|------------------|
+| EPYC 9004 (Genoa) | Zen 4 | ✅ Yes | `AVX512_CORE_BF16` |
+| EPYC 9005 (Turin) | Zen 5 | ✅ Yes | `AVX512_CORE_BF16` |
+| EPYC 4004 | Zen 4 | ✅ Yes | `AVX512_CORE_BF16` |
+| Ryzen 9000 | Zen 5 | ✅ Yes | `AVX512_CORE_BF16` |
+| EPYC 7003 (Milan) | Zen 3 | ❌ No | `AVX2` |
+
+### AMD vs Intel Feature Comparison
+
+| Feature | AMD Zen 4/5 | Intel Sapphire Rapids+ | oneDNN Support |
+|---------|-------------|------------------------|----------------|
+| AVX2 | ✅ Yes | ✅ Yes | ✅ Full |
+| AVX512F/BW/VL/DQ | ✅ Yes | ✅ Yes | ✅ Full |
+| AVX512_VNNI | ✅ Yes | ✅ Yes | ✅ Full |
+| AVX512BF16 | ✅ Yes | ✅ Yes | ✅ Full |
+| AVX512_FP16 | ❌ No | ✅ Yes | N/A on AMD |
+| AMX (Tile Matrix) | ❌ No | ✅ Yes | N/A on AMD |
+
+**Key Point:** AMD EPYC Genoa (Zen 4) achieves `AVX512_CORE_BF16` level in oneDNN, which covers all linear layer optimizations including BF16 compute.
+
+### AMD Performance Characteristics
+
+Recent benchmarks (2024-2025) show:
+- **59% higher performance** with AVX512 vs AVX2 on Zen 4
+- AMD's AVX512 implementation avoids Intel's historical throttling issues
+- No clock speed penalties (AMD uses 256-bit "double pumping" internally)
+- PyTorch + oneDNN benchmarks show AMD EPYC competitive with Intel Xeon
+
+### Verification on AMD Systems
+
+```bash
+# Check oneDNN ISA detection on AMD
+ONEDNN_VERBOSE=1 python -c "
+import torch
+x = torch.randn(1000, 1000)
+y = torch.matmul(x, x)
+" 2>&1 | grep -E "avx512|bf16|isa"
+```
+
+**Expected output on AMD EPYC Genoa:**
+```
+onednn_verbose,info,cpu,runtime:OpenMP,nthr:128
+onednn_verbose,info,cpu,isa:Intel AVX-512 with AVX512BW, AVX512VL, AVX512DQ and AVX512_BF16 extensions
+```
+
+Note: The output says "Intel AVX-512" because that's the ISA name, not the CPU vendor. oneDNN detects the **instructions**, not the CPU brand.
+
+### AMD-Specific Considerations
+
+1. **No AMX on AMD:** AMD Zen 4/5 does not support AMX (Advanced Matrix Extensions), so the `vllm-cpu-amxbf16` variant provides no benefit on AMD. Use `vllm-cpu-avx512bf16` instead.
+
+2. **Double-Pumping:** AMD implements AVX512 using two 256-bit cycles internally. This means:
+   - More power-efficient than Intel's native 512-bit execution
+   - No clock throttling issues
+   - Performance is still excellent for most workloads
+
+3. **ZenDNN Alternative:** AMD provides [ZenDNN](https://github.com/amd/ZenDNN) as an AMD-optimized alternative to oneDNN. However, for vLLM compatibility and broad support, oneDNN is recommended.
+
+## Conclusion
+
+### Research Summary
+
+This document consolidates extensive research on runtime ISA dispatch mechanisms. Key findings:
+
+| Finding | Confidence | Evidence |
+|---------|------------|----------|
+| Upstream unified wheel requires AVX512 minimum | **95%** | CMake uses if/elseif, not multi-compile |
+| GCC target_clones is the cleanest unified solution | **90%** | Zero overhead, compiler-managed |
+| Our 5-wheel approach is industry-validated | **95%** | Separate packages is a legitimate pattern |
+| oneDNN JIT works on AMD Zen 4 | **95%** | CPUID-based detection, not vendor |
+
+### Recommended Strategy
+
+Based on industry research and upstream analysis:
+
+#### Primary Recommendation: Keep 5 Wheels
+
+Our current approach is **validated by industry research** as a legitimate strategy:
+
+```
+vllm-cpu           → AVX2-only CPUs (Haswell, Milan, etc.)  ← Fills upstream gap
+vllm-cpu-avx512    → Basic AVX512 (Skylake-X)
+vllm-cpu-avx512vnni → AVX512 + VNNI (Cascade Lake)
+vllm-cpu-avx512bf16 → AVX512 + BF16 (Cooper Lake, AMD Genoa)
+vllm-cpu-amxbf16    → AVX512 + AMX (Sapphire Rapids)
+```
+
+**Why this is correct:**
+1. ✅ Zero runtime overhead (no dispatch)
+2. ✅ Explicit ISA guarantee
+3. ✅ Broadest CPU support (AVX2 included, unlike upstream)
+4. ✅ Same pattern used by major projects (package variants)
+5. ✅ Simple build system, no upstream changes needed
+
+#### Future Option: True Unified Wheel with target_clones
+
+If we ever want a single wheel for all x86 CPUs:
+
+1. **Add `target_clones` to vLLM kernels** (requires upstream PR)
+2. **Compile once, dispatch automatically** via IFUNC
+3. **Binary size ~3-4× larger** but single wheel
+4. **Performance identical** to ISA-specific wheels
+
+This requires vLLM upstream buy-in but is the cleanest long-term solution.
+
+
+### CPU Compatibility Matrix
+
+| CPU | Upstream Wheel | Our Wheels | Best Choice |
+|-----|----------------|------------|-------------|
+| Intel Haswell (AVX2) | ❌ Crashes | ✅ vllm-cpu | vllm-cpu |
+| AMD EPYC Milan (AVX2) | ❌ Crashes | ✅ vllm-cpu | vllm-cpu |
+| Intel Skylake-X (AVX512) | ✅ Works | ✅ vllm-cpu-avx512 | Either |
+| AMD EPYC Genoa (AVX512+BF16) | ✅ Works | ✅ vllm-cpu-avx512bf16 | Either |
+| Intel Sapphire Rapids (AMX) | ✅ Works | ✅ vllm-cpu-amxbf16 | Either |
+
+### Performance Impact Summary
+
+| Scenario | Overhead |
+|----------|----------|
+| Our ISA-specific wheels | **0%** (optimal) |
+| Upstream runtime dispatch | **<0.5%** |
+| GCC target_clones (if implemented) | **0%** (IFUNC) |
+
+### Action Items
+
+1. ✅ **Keep current 5-wheel approach** - Validated, working, broadest compatibility
+2. ✅ **Document upstream AVX512 requirement** - Users should know the limitation
+3. ⏳ **Consider proposing target_clones to upstream** - Would benefit entire community
+4. ⏳ **Monitor upstream for AVX2 support** - If added, we could simplify
+
+---
+
+## Appendix: Multi-ISA Unified Wheel Implementation Plan
+
+This section documents the concrete implementation for a multi-ISA unified wheel approach, based on collaboration with Daniele who has achieved a working prototype.
+
+### Current Progress (December 2025)
+
+**Branch:** https://github.com/dtrifiro/vllm/tree/cpu-build-dispatcher
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Multi-ISA CMake build | ✅ Compiles | Two extensions: `_C` (AVX2) and `_C_avx512` |
+| Runtime ISA dispatch | ✅ Working | Uses `torch.cpu._is_avx512_supported()` |
+| torch.ops module registration | ⚠️ **Problem** | Extensions register to DIFFERENT namespaces |
+| **AVX2 import** | ✅ Works | Module loads successfully |
+| **AVX2 server start** | ✅ Works | Server initializes |
+| **AVX2 inference** | ❌ **Crashes** | torch.ops namespace mismatch |
+| **AVX512 import** | ✅ Works | Module loads successfully |
+| **AVX512 server start** | ✅ Works | Server initializes |
+| **AVX512 inference** | ❌ **Crashes** | torch.ops namespace mismatch (same issue) |
+
+**Latest Update (from Daniele):** Both AVX2 and AVX512 paths have the **same issue** - they crash during inference due to torch.ops namespace problems. The server spins up successfully in both cases but crashes when calling ops.
+
+**Root Cause:** The two extensions register to different namespaces:
+- `_C.so` (AVX2) registers → `torch.ops._C.*`
+- `_C_avx512.so` (AVX512) registers → `torch.ops._C_avx512.*`
+
+But vLLM Python code hardcodes calls to `torch.ops._C.something()`, which fails when the AVX512 extension is loaded (and vice versa for ops only in AVX512).
+
+**Proposed Fixes (from Daniele):**
+
+| Fix | Location | Description |
+|-----|----------|-------------|
+| **A. Unified namespace** | `torch_bindings.cpp` | Make BOTH extensions register to `torch.ops._C.*` |
+| **B. Dynamic dispatch** | Python call sites | Find correct `torch.ops._C*` module at runtime |
+
+**Fix A - Unified Namespace (Recommended):**
+```cpp
+// In torch_bindings.cpp - both extensions use same namespace
+TORCH_LIBRARY(_C, m) {  // NOT _C_avx512
+    m.def("activation_silu_and_mul", ...);
+    m.def("onednn_mm", ...);  // Only if this extension has it
+}
+```
+
+**Fix B - Dynamic Dispatch:**
+```python
+# Create a dispatcher module that finds the right ops
+import torch
+
+def get_ops():
+    """Return whichever _C module is loaded."""
+    if hasattr(torch.ops, '_C') and hasattr(torch.ops._C, 'activation_silu_and_mul'):
+        return torch.ops._C
+    elif hasattr(torch.ops, '_C_avx512'):
+        return torch.ops._C_avx512
+    else:
+        raise RuntimeError("No vLLM CPU extension loaded")
+
+# Usage: get_ops().activation_silu_and_mul(...)
+```
+
+**Consideration for Fix A:** If both extensions register to `_C`, they must have the **same function signatures**. Operations that only exist in AVX512 (like `onednn_mm`) would need:
+- Stub implementations in AVX2 that raise NotImplementedError, OR
+- Conditional registration with `#ifdef` guards
+
+### Daniele's Implementation Analysis
+
+After analyzing the branch, here's what's implemented:
+
+**Architecture: Separate .so Files**
+
+Daniele's approach builds **two separate shared libraries** that ship in one wheel:
+```
+vllm/
+├── _C.cpython-312-x86_64-linux-gnu.so        # AVX2 extension (~X MB)
+└── _C_avx512.cpython-312-x86_64-linux-gnu.so # AVX512 extension (~X MB)
+```
+
+At runtime, only ONE is loaded based on CPU detection. This differs from IPEX's single-binary approach where all ISA variants are compiled into one `.so` with internal dispatch.
+
+| Approach | Files in Wheel | Runtime Loading | Dispatch Mechanism |
+|----------|----------------|-----------------|-------------------|
+| **Daniele's (separate .so)** | `_C.so` + `_C_avx512.so` | Load ONE based on CPUID | Module selection |
+| **IPEX (single binary)** | One `_C.so` | Load single file | Internal function pointers |
+| **Our current (separate wheels)** | One `_C.so` per wheel | N/A | N/A (user selects wheel) |
+
+**1. cmake/cpu_extension.cmake**
+```cmake
+# AVX2 Extension (_C) - base implementation
+define_extension_target(
+    _C
+    SOURCES ${VLLM_EXT_SRC}
+    COMPILE_FLAGS ${CXX_COMPILE_FLAGS_AVX2}
+)
+
+# AVX512 Extension (_C_avx512) - includes extra kernels
+define_extension_target(
+    _C_avx512
+    SOURCES ${VLLM_EXT_AVX512_SRC}  # Includes shm.cpp, wna16.cpp, fused_moe.cpp + AVX2 sources
+    COMPILE_FLAGS ${CXX_COMPILE_FLAGS_AVX512}
+    LIBRARIES ${LIBS_AVX512}  # Includes oneDNN
+)
+```
+
+**2. vllm/platforms/cpu.py - Module Loader**
+```python
+@classmethod
+def import_kernels(cls) -> None:
+    """Import platform-specific C kernels based on CPU capabilities."""
+    if torch.cpu._is_avx512_supported():
+        module = "vllm._C_avx512"
+    elif torch.cpu._is_avx2_supported():
+        module = "vllm._C"
+    else:
+        raise NotImplementedError("This requires AVX2 or AVX512.")
+
+    importlib.import_module(module)  # Loads ONE extension based on CPU
+```
+
+**3. vllm/v1/worker/cpu_worker.py - Try/Except Fallback**
+```python
+# Try AVX2 module first, fall back to AVX512
+try:
+    ret = torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
+except:
+    ret = torch.ops._C_avx512_utils.init_cpu_threads_env(self.local_omp_cpuid)
+```
+
+### How Daniele's Dispatch Works
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    vllm/platforms/cpu.py                         │
+│  torch.cpu._is_avx512_supported() → CPUID detection             │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+              ┌───────────────┴───────────────┐
+              │                               │
+              ▼                               ▼
+      Load vllm._C                    Load vllm._C_avx512
+      (AVX2 extension)                (AVX512 extension)
+              │                               │
+              ▼                               ▼
+    Registers torch.ops._C            Registers torch.ops._C_avx512
+    Registers torch.ops._C_utils      Registers torch.ops._C_avx512_utils
+              │                               │
+              └───────────────┬───────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              vllm/v1/worker/cpu_worker.py                        │
+│  try: torch.ops._C_utils.init_cpu_threads_env()                  │
+│  except: torch.ops._C_avx512_utils.init_cpu_threads_env()        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Key Insight:** Only ONE extension is loaded based on CPU detection. The try/except in cpu_worker.py handles whichever module was loaded:
+- On AVX512 CPU: `_C` not loaded → exception → uses `_C_avx512_utils` ✅
+- On AVX2 CPU: `_C` loaded → uses `_C_utils` directly ✅
+
+### Remaining Issues
+
+**1. torch.ops Namespace Mismatch (Primary Blocker)**
+
+Both AVX2 and AVX512 paths fail during inference due to the **same root cause**: torch.ops namespace mismatch.
+
+**The Problem:**
+```
+vLLM Python code calls:     torch.ops._C.some_function(...)
+But AVX512 extension registers: torch.ops._C_avx512.some_function(...)
+Result: AttributeError or RuntimeError
+```
+
+**Root Cause Analysis (Updated):**
+
+| Suspect | Likelihood | Reason |
+|---------|------------|--------|
+| torch.ops namespace mismatch | 🔴 **Confirmed** | Extensions register different namespaces |
+| Missing oneDNN in AVX2 | 🟡 Secondary | AVX2 lacks some ops, but namespace is primary issue |
+| Attention kernel dispatch | 🟢 Low | ISA selection returns "vec" which has AVX2 fallback |
+
+**2. AVX2-Specific: Missing Operations**
+
+Even after fixing namespace, AVX2 build is missing some operations:
+
+**AVX2 Build Missing Components:**
+
+| Source File | Purpose | In AVX2? | In AVX512? |
+|-------------|---------|----------|------------|
+| `dnnl_kernels.cpp` | oneDNN GEMM wrappers | ❌ **NO** | ✅ Yes |
+| `shm.cpp` | SHM CCL communication | ❌ NO | ✅ Yes |
+| `cpu_wna16.cpp` | WNA16 quantization kernels | ❌ NO | ✅ Yes |
+| `cpu_fused_moe.cpp` | Fused MoE kernels | ❌ NO | ✅ Yes |
+| `activation.cpp` | Activation functions | ✅ Yes | ✅ Yes |
+| `layernorm.cpp` | Layer normalization | ✅ Yes | ✅ Yes |
+| `cpu_attn.cpp` | Attention kernels | ✅ Yes | ✅ Yes |
+
+**Operations NOT registered in AVX2 build:**
+```cpp
+// These torch.ops only exist in AVX512 build (_C_avx512):
+torch.ops._C_avx512.onednn_mm(...)           // Dense GEMM - CRITICAL for inference
+torch.ops._C_avx512.onednn_scaled_mm(...)    // Scaled GEMM
+torch.ops._C_avx512.static_scaled_int8_quant(...) // INT8 quantization
+torch.ops._C_avx512.init_shm_manager(...)    // SHM init
+torch.ops._C_avx512.shm_allreduce(...)       // SHM collective
+torch.ops._C_avx512.cpu_gemm_wna16(...)      // WNA16 GEMM
+torch.ops._C_avx512.cpu_fused_moe(...)       // Fused MoE
+```
+
+**Why generate() fails:**
+
+During inference, vLLM calls linear layers which use `onednn_mm` for matrix multiplication:
+```
+User calls: llm.generate("Hello")
+    → Model forward pass
+    → nn.Linear layers
+    → Calls torch.ops._C.onednn_mm(...)  ← FAILS: op doesn't exist in AVX2 build
+```
+
+**Expected error message:**
+```
+RuntimeError: operator 'vllm::onednn_mm' does not exist
+# or
+AttributeError: module 'torch.ops._C' has no attribute 'onednn_mm'
+```
+
+**Potential Fixes:**
+
+| Fix | Effort | Description |
+|-----|--------|-------------|
+| **A. Add oneDNN to AVX2** | Medium | Link `dnnl_ext` and include `dnnl_kernels.cpp` in AVX2 build |
+| **B. PyTorch fallback** | Low | If `onednn_mm` missing, fall back to `torch.mm()` or `torch.matmul()` |
+| **C. Conditional dispatch** | Low | Check if op exists before calling, use fallback if not |
+
+**Recommended fix (B or C):**
+```python
+# In vLLM Python code that calls onednn_mm:
+def linear_forward(x, weight):
+    if hasattr(torch.ops._C, 'onednn_mm'):
+        return torch.ops._C.onednn_mm(x, weight)
+    elif hasattr(torch.ops._C_avx512, 'onednn_mm'):
+        return torch.ops._C_avx512.onednn_mm(x, weight)
+    else:
+        # Fallback to PyTorch native (still uses oneDNN JIT internally)
+        return torch.mm(x, weight)
+```
+
+**Note:** Even without the custom `onednn_mm` op, PyTorch's native `torch.mm()` still uses oneDNN JIT under the hood, so performance should be similar.
+
+**Debug steps:**
+```bash
+# Get exact error and stack trace
+python -c "
+from vllm import LLM
+llm = LLM('facebook/opt-125m')
+print('Model loaded OK')
+output = llm.generate('Hello')  # This fails
+"
+
+# With GDB for C++ stack trace
+gdb -ex run -ex bt -ex quit --args python -c "from vllm import LLM; LLM('facebook/opt-125m').generate('Hello')"
+```
+
+**2. torch.cpu._is_avx512_supported() API Stability**
+
+Uses internal PyTorch APIs (underscore prefix). If these change, detection could break.
+
+Alternative detection methods:
+```python
+# Option A: cpuinfo package (more reliable)
+import cpuinfo
+'avx512f' in cpuinfo.get_cpu_info().get('flags', [])
+
+# Option B: /proc/cpuinfo (Linux only)
+'avx512f' in open('/proc/cpuinfo').read()
+```
+
+**3. Missing: vllm/worker/cpu_worker.py (non-v1)**
+
+The non-v1 worker may not have been updated. Needs verification.
+
+### Code Review Findings
+
+#### Build Configuration Differences
+
+| Source File | AVX2 (`_C`) | AVX512 (`_C_avx512`) |
+|-------------|-------------|----------------------|
+| activation.cpp | ✅ | ✅ |
+| utils.cpp | ✅ | ✅ |
+| layernorm.cpp | ✅ | ✅ |
+| cpu_attn.cpp | ✅ | ✅ |
+| torch_bindings.cpp | ✅ | ✅ |
+| shm.cpp | ❌ | ✅ |
+| cpu_wna16.cpp | ❌ | ✅ |
+| cpu_fused_moe.cpp | ❌ | ✅ |
+| dnnl_kernels.cpp | ❌ | ✅ |
+
+#### Vector Types (cpu_types_x86.hpp)
+
+| Type | AVX512 | AVX2 Fallback |
+|------|--------|---------------|
+| `FP32Vec16` | `__m512` | `__m256 × 2` ✅ |
+| `BF16Vec32` | `__m512i` | `__m256i × 2` ✅ |
+| `BF16Vec16` | `__m256i` | ✅ |
+| `INT32Vec16` | `__m512i` | ❌ Missing |
+| `INT8Vec16` | `__m128i` | ❌ Missing |
+
+#### Attention ISA Selection
+
+From `vllm/v1/attention/backends/cpu_attn.py`:
+```python
+def _get_attn_isa(dtype, block_size):
+    if supports_amx and dtype == bfloat16 and block_size % 32 == 0:
+        return "amx"
+    elif block_size % 32 == 0:
+        if ARM: return "neon"
+        else: return "vec"   # ← AVX2 x86 uses this
+    else:
+        return "vec16"
+```
+
+The `"vec"` ISA uses `AttentionImpl<ISA::VEC>` which relies on `FP32Vec16` - this HAS an AVX2 fallback, so attention should work.
+
+### What Daniele Already Implemented
+
+Daniele's branch has already implemented the dispatch mechanism, which differs slightly from our original plan:
+
+| Component | Our Original Plan | Daniele's Implementation |
+|-----------|-------------------|--------------------------|
+| CPU Detection | `cpuinfo` or `/proc/cpuinfo` | `torch.cpu._is_avx512_supported()` |
+| Module Loading | Load both, select at runtime | Load ONE based on detection |
+| Call Site Dispatch | `get_utils()` helper function | Try/except fallback pattern |
+
+**Daniele's Approach Advantages:**
+- Simpler (loads only one module)
+- Lower memory usage (only one extension in memory)
+- No dispatcher module needed
+
+**Daniele's Approach Disadvantages:**
+- Try/except pattern adds exception handling overhead
+- Relies on internal PyTorch APIs (`torch.cpu._is_*`)
+- Less explicit than a dedicated dispatcher
+
+### Next Steps to Complete Implementation
+
+**1. Debug the bad_alloc Issue (Primary)**
+
+The AVX2 crash needs investigation. Debug steps:
+```bash
+# Memory debugger
+valgrind --tool=memcheck python -c "from vllm import LLM"
+
+# GDB with exception catching
+gdb --args python -c "from vllm import LLM"
+(gdb) catch throw
+(gdb) run
+```
+
+Possible causes to investigate:
+- Missing AVX2 implementations for certain kernels
+- Buffer size assumptions (AVX512 vs AVX2 register widths)
+- Conditional compilation issues (`#ifdef __AVX512F__` without fallback)
+
+**2. Verify non-v1 Worker (Minor)**
+
+Check if `vllm/worker/cpu_worker.py` has the same try/except pattern.
+
+**3. Consider API Stability (Future)**
+
+If `torch.cpu._is_avx512_supported()` proves unstable, fallback to:
+```python
+import cpuinfo
+'avx512f' in cpuinfo.get_cpu_info().get('flags', [])
+```
+
+### Alternative Dispatcher (If Needed)
+
+If the try/except pattern causes issues, here's a cleaner dispatcher approach:
+
+**File: `vllm/platforms/cpu_ops.py`**
+```python
+import torch
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def get_utils():
+    """Get the correct utils module based on loaded extension."""
+    if hasattr(torch.ops, '_C_avx512_utils'):
+        return torch.ops._C_avx512_utils
+    elif hasattr(torch.ops, '_C_utils'):
+        return torch.ops._C_utils
+    else:
+        raise RuntimeError("No vLLM CPU extension loaded")
+
+# Usage: get_utils().init_cpu_threads_env(...)
+```
+
+### Effort Summary (Updated)
+
+| Task | Time | Status |
+|------|------|--------|
+| CMake multi-ISA build | N/A | ✅ Done by Daniele |
+| Platform detection | N/A | ✅ Done by Daniele |
+| Module loading | N/A | ✅ Done by Daniele |
+| AVX2 import/server start | N/A | ✅ Working |
+| AVX512 import/server start | N/A | ✅ Working |
+| **Fix namespace mismatch** | 2-4 hours | 🔴 **Primary blocker** |
+| Handle AVX2 missing ops | 1-2 hours | 🟡 Secondary (after namespace fix) |
+| End-to-end testing | 1-2 hours | ⚠️ Pending |
+| **Total Remaining** | **~0.5-1 day** | |
+
+### Confidence Assessment
+
+| Aspect | Confidence | Reasoning |
+|--------|------------|-----------|
+| Both paths import/start OK | **95%** | Confirmed by Daniele on both AVX2 and AVX512 |
+| Root cause identified | **95%** | Namespace mismatch confirmed by Daniele |
+| Fix A (unified namespace) viable | **85%** | Standard pattern, but needs careful op registration |
+| Fix B (dynamic dispatch) viable | **90%** | Pure Python, no C++ changes needed |
+| AVX2 missing ops manageable | **80%** | Can use PyTorch fallbacks for missing oneDNN ops |
+| Upstream merge potential | **60%** | Depends on code quality and maintainer interest |
+
+### Next Steps
+
+1. **Fix namespace mismatch** (Primary) - Choose one approach:
+   - **Fix A:** Modify `torch_bindings.cpp` to use unified `_C` namespace for both extensions
+   - **Fix B:** Add Python dispatcher that finds correct `torch.ops._C*` module
+
+2. **Handle AVX2 missing ops** (Secondary) - After namespace fix:
+   - Add PyTorch fallbacks for `onednn_mm` → `torch.mm()`
+   - Or add stub implementations that raise clear errors
+
+3. **End-to-end testing:**
+   - Test on AVX2 system (Daniele + user)
+   - Test on AVX512 system (user's AMD AVX512BF16)
+   - Verify both paths complete inference successfully
+
+---
+
+## Implementation Guide: Fix B (Python Dynamic Dispatcher)
+
+This section provides a complete implementation guide for fixing the namespace mismatch using Python dynamic dispatch. This approach is recommended because:
+- No C++ recompilation required
+- Less invasive changes
+- Easier to test and debug
+
+### Overview
+
+The fix creates a dispatcher module that routes `torch.ops._C.*` calls to whichever extension is loaded (`_C` or `_C_avx512`).
+
+### Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `vllm/_ops_dispatch.py` | **CREATE** | New dispatcher module |
+| `vllm/_custom_ops.py` | **MODIFY** | Update ~100+ call sites |
+| `vllm/v1/worker/cpu_worker.py` | **VERIFY** | Already has try/except pattern |
+
+### Step 1: Create Dispatcher Module
+
+**File: `vllm/_ops_dispatch.py`**
+
+```python
+"""
+Dynamic dispatcher for CPU extension operations.
+
+This module provides a unified interface to torch.ops regardless of which
+CPU extension is loaded (_C for AVX2 or _C_avx512 for AVX512).
+
+The dispatcher detects which extension is available and routes calls
+to the correct namespace.
+"""
+
+import torch
+from functools import lru_cache
+from typing import Any, Optional
+
+
+@lru_cache(maxsize=1)
+def _detect_cpu_extension() -> str:
+    """
+    Detect which CPU extension is loaded.
+
+    Returns:
+        "_C" if AVX2 extension loaded
+        "_C_avx512" if AVX512 extension loaded
+        "" if no CPU extension (CUDA build)
+    """
+    # Check for AVX512 extension first (more specific)
+    if hasattr(torch.ops, '_C_avx512'):
+        # Verify it has actual ops registered
+        if hasattr(torch.ops._C_avx512, 'silu_and_mul'):
+            return "_C_avx512"
+
+    # Check for AVX2 extension
+    if hasattr(torch.ops, '_C'):
+        # Verify it has CPU ops (not just CUDA ops)
+        if hasattr(torch.ops._C, 'silu_and_mul'):
+            return "_C"
+
+    # No CPU extension loaded (probably CUDA build)
+    return ""
+
+
+@lru_cache(maxsize=1)
+def get_ops():
+    """
+    Get the correct torch.ops module for CPU operations.
+
+    Returns:
+        torch.ops._C or torch.ops._C_avx512 depending on loaded extension
+
+    Raises:
+        RuntimeError: If no CPU extension is loaded
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        return torch.ops._C_avx512
+    elif ext == "_C":
+        return torch.ops._C
+    else:
+        # Fall back to _C for CUDA builds (they register ops there)
+        return torch.ops._C
+
+
+@lru_cache(maxsize=1)
+def get_utils():
+    """
+    Get the correct torch.ops utils module.
+
+    Returns:
+        torch.ops._C_utils or torch.ops._C_avx512_utils
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        return torch.ops._C_avx512_utils
+    elif ext == "_C":
+        return torch.ops._C_utils
+    else:
+        # CUDA build - utils might be in _C_cuda_utils
+        if hasattr(torch.ops, '_C_utils'):
+            return torch.ops._C_utils
+        raise RuntimeError("No utils extension loaded")
+
+
+@lru_cache(maxsize=1)
+def get_cpu_ops():
+    """
+    Get the correct torch.ops CPU-specific module.
+
+    Returns:
+        torch.ops._C_cpu or torch.ops._C_avx512_cpu
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        if hasattr(torch.ops, '_C_avx512_cpu'):
+            return torch.ops._C_avx512_cpu
+    if hasattr(torch.ops, '_C_cpu'):
+        return torch.ops._C_cpu
+    raise RuntimeError("No CPU ops extension loaded")
+
+
+def has_op(op_name: str) -> bool:
+    """
+    Check if an operation is available in the loaded extension.
+
+    Args:
+        op_name: Name of the operation (e.g., "onednn_mm")
+
+    Returns:
+        True if operation exists, False otherwise
+    """
+    ops = get_ops()
+    return hasattr(ops, op_name)
+
+
+def get_op(op_name: str) -> Optional[Any]:
+    """
+    Get an operation by name, or None if not available.
+
+    Args:
+        op_name: Name of the operation
+
+    Returns:
+        The operation callable, or None
+    """
+    ops = get_ops()
+    return getattr(ops, op_name, None)
+
+
+# Convenience: expose commonly used ops directly
+# These will be resolved on first access
+class _OpsProxy:
+    """Proxy object that forwards attribute access to the correct ops module."""
+
+    def __getattr__(self, name: str) -> Any:
+        ops = get_ops()
+        return getattr(ops, name)
+
+
+# Global instance for easy access
+ops = _OpsProxy()
+```
+
+### Step 2: Update _custom_ops.py Call Sites
+
+The file `vllm/_custom_ops.py` has ~100+ call sites that use `torch.ops._C.*`. These need to be updated to use the dispatcher.
+
+**Pattern to apply:**
+
+```python
+# BEFORE:
+torch.ops._C.some_operation(args)
+
+# AFTER:
+from vllm._ops_dispatch import get_ops
+get_ops().some_operation(args)
+
+# OR for frequently called ops, cache at module level:
+from vllm._ops_dispatch import ops
+ops.some_operation(args)
+```
+
+**Call Sites to Update (by category):**
+
+#### Activation Functions (~6 calls)
+| Line | Before | After |
+|------|--------|-------|
+| ~136 | `torch.ops._C.silu_and_mul(...)` | `get_ops().silu_and_mul(...)` |
+| ~140 | `torch.ops._C.gelu_and_mul(...)` | `get_ops().gelu_and_mul(...)` |
+| ~144 | `torch.ops._C.gelu_tanh_and_mul(...)` | `get_ops().gelu_tanh_and_mul(...)` |
+| ~148 | `torch.ops._C.gelu_new(...)` | `get_ops().gelu_new(...)` |
+| ~152 | `torch.ops._C.gelu_fast(...)` | `get_ops().gelu_fast(...)` |
+| ~156 | `torch.ops._C.gelu_quick(...)` | `get_ops().gelu_quick(...)` |
+
+#### Normalization Functions (~2 calls)
+| Line | Before | After |
+|------|--------|-------|
+| ~331 | `torch.ops._C.rms_norm(...)` | `get_ops().rms_norm(...)` |
+| ~337 | `torch.ops._C.fused_add_rms_norm(...)` | `get_ops().fused_add_rms_norm(...)` |
+
+#### Rotary Embedding (~1 call)
+| Line | Before | After |
+|------|--------|-------|
+| ~322 | `torch.ops._C.rotary_embedding(...)` | `get_ops().rotary_embedding(...)` |
+
+#### oneDNN Operations (~10 calls) - CPU-specific
+| Line | Before | After |
+|------|--------|-------|
+| ~2710 | `torch.ops._C.release_dnnl_matmul_handler(...)` | `get_ops().release_dnnl_matmul_handler(...)` |
+| ~2713 | `hasattr(torch.ops._C, "create_onednn_mm_handler")` | `has_op("create_onednn_mm_handler")` |
+| ~2717 | `torch.ops._C.is_onednn_acl_supported()` | `get_ops().is_onednn_acl_supported()` |
+| ~2726 | `torch.ops._C.create_onednn_mm_handler(...)` | `get_ops().create_onednn_mm_handler(...)` |
+| ~2738 | `torch.ops._C.onednn_mm(...)` | `get_ops().onednn_mm(...)` |
+| ~2755 | `torch.ops._C.create_onednn_scaled_mm_handler(...)` | `get_ops().create_onednn_scaled_mm_handler(...)` |
+| ~2789 | `torch.ops._C.static_scaled_int8_quant(...)` | `get_ops().static_scaled_int8_quant(...)` |
+| ~2795 | `torch.ops._C.dynamic_scaled_int8_quant(...)` | `get_ops().dynamic_scaled_int8_quant(...)` |
+| ~2808 | `torch.ops._C.onednn_scaled_mm(...)` | `get_ops().onednn_scaled_mm(...)` |
+
+#### CPU Attention Operations (~3 calls)
+| Line | Before | After |
+|------|--------|-------|
+| ~2828 | `torch.ops._C.get_scheduler_metadata(...)` | `get_ops().get_scheduler_metadata(...)` |
+| ~2852 | `torch.ops._C.cpu_attn_reshape_and_cache(...)` | `get_ops().cpu_attn_reshape_and_cache(...)` |
+| ~2878 | `torch.ops._C.cpu_attention_with_kv_cache(...)` | `get_ops().cpu_attention_with_kv_cache(...)` |
+
+#### CPU MoE/GEMM Operations (~3 calls)
+| Line | Before | After |
+|------|--------|-------|
+| ~2908 | `torch.ops._C.cpu_gemm_wna16(...)` | `get_ops().cpu_gemm_wna16(...)` |
+| ~2927 | `torch.ops._C.prepack_moe_weight(...)` | `get_ops().prepack_moe_weight(...)` |
+| ~2943 | `torch.ops._C.cpu_fused_moe(...)` | `get_ops().cpu_fused_moe(...)` |
+
+#### Capability Checks (~15+ calls)
+| Pattern | Before | After |
+|---------|--------|-------|
+| Feature check | `hasattr(torch.ops._C, "op_name")` | `has_op("op_name")` |
+
+**Note:** Many other calls in `_custom_ops.py` are CUDA-specific (cutlass, marlin, etc.) and don't need updating for CPU dispatch.
+
+### Step 3: Update cpu_worker.py
+
+The file already has a try/except pattern. Update to use dispatcher:
+
+```python
+# BEFORE (lines 85-87):
+try:
+    ret = torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
+except:
+    ret = torch.ops._C_avx512_utils.init_cpu_threads_env(self.local_omp_cpuid)
+
+# AFTER:
+from vllm._ops_dispatch import get_utils
+ret = get_utils().init_cpu_threads_env(self.local_omp_cpuid)
+```
+
+### Step 4: Handle Missing AVX2 Operations
+
+Some operations only exist in AVX512 build. Add fallbacks:
+
+```python
+# In _custom_ops.py or _ops_dispatch.py
+
+def onednn_mm_with_fallback(input, weight, bias=None):
+    """
+    Matrix multiplication with fallback for AVX2 builds.
+    """
+    if has_op("onednn_mm"):
+        return get_ops().onednn_mm(input, weight, bias)
+    else:
+        # Fallback to PyTorch native (still uses oneDNN JIT internally)
+        result = torch.mm(input, weight)
+        if bias is not None:
+            result = result + bias
+        return result
+```
+
+### Operations Available by Build
+
+| Operation | AVX2 Build | AVX512 Build | Fallback |
+|-----------|------------|--------------|----------|
+| `silu_and_mul` | ✅ | ✅ | N/A |
+| `gelu_and_mul` | ✅ | ✅ | N/A |
+| `rms_norm` | ✅ | ✅ | N/A |
+| `fused_add_rms_norm` | ✅ | ✅ | N/A |
+| `rotary_embedding` | ✅ | ✅ | N/A |
+| `onednn_mm` | ❌ | ✅ | `torch.mm()` |
+| `onednn_scaled_mm` | ❌ | ✅ | `torch.mm()` + scale |
+| `static_scaled_int8_quant` | ❌ | ✅ | PyTorch quantization |
+| `dynamic_scaled_int8_quant` | ❌ | ✅ | PyTorch quantization |
+| `cpu_gemm_wna16` | ❌ | ✅ | Error (no fallback) |
+| `cpu_fused_moe` | ❌ | ✅ | Error (no fallback) |
+| `init_shm_manager` | ❌ | ✅ | Error (no fallback) |
+| `shm_allreduce` | ❌ | ✅ | Error (no fallback) |
+
+### Testing Checklist
+
+After implementing the fix:
+
+- [ ] AVX2 system: `import vllm` succeeds
+- [ ] AVX2 system: `LLM("facebook/opt-125m")` loads
+- [ ] AVX2 system: `llm.generate("Hello")` completes
+- [ ] AVX512 system: `import vllm` succeeds
+- [ ] AVX512 system: `LLM("facebook/opt-125m")` loads
+- [ ] AVX512 system: `llm.generate("Hello")` completes
+- [ ] Verify correct extension loaded: `from vllm._ops_dispatch import _detect_cpu_extension; print(_detect_cpu_extension())`
+
+---
+
+## Quick Reference Summary
+
+### Problem
+Two separate `.so` files register to different torch.ops namespaces, but Python code hardcodes one namespace.
+
+### Solution (Fix B - Python Dispatcher)
+1. Create `vllm/_ops_dispatch.py` with `get_ops()`, `get_utils()`, `has_op()` functions
+2. Update `vllm/_custom_ops.py` call sites (~25 CPU-related calls)
+3. Update `vllm/v1/worker/cpu_worker.py` to use dispatcher
+
+### Key Files
+| File | Purpose |
+|------|---------|
+| `vllm/_ops_dispatch.py` | **CREATE** - Dispatcher module |
+| `vllm/_custom_ops.py` | **MODIFY** - ~25 CPU-related call sites |
+| `vllm/v1/worker/cpu_worker.py` | **MODIFY** - 1 call site |
+| `csrc/cpu/torch_bindings.cpp` | Reference only (no changes needed) |
+
+### Commands to Test
+```bash
+# Check which extension is loaded
+python -c "from vllm._ops_dispatch import _detect_cpu_extension; print(_detect_cpu_extension())"
+
+# Test full inference
+python -c "from vllm import LLM; llm = LLM('facebook/opt-125m'); print(llm.generate('Hello'))"
+```
+
+### Estimated Effort
+- Create dispatcher: 30 min
+- Update call sites: 1-2 hours
+- Testing: 1 hour
+- **Total: ~3-4 hours**
+
+---
+
+## Future Considerations
+
+- Monitor PyTorch Inductor improvements for CPU
+- Watch for vLLM upstream AVX2 support (currently missing)
+- Consider AVX10.2 support as Intel releases new CPUs
+- Track AMD Zen 5 and future ARM improvements
+- Evaluate target_clones PR to vLLM upstream

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -14,6 +14,10 @@ logger = init_logger(__name__)
 
 current_platform.import_kernels()
 
+# Import dispatcher for CPU multi-ISA support
+# This routes torch.ops calls to _C or _C_avx512 depending on loaded extension
+from vllm._ops_dispatch import get_ops, get_cpu_ops, has_op
+
 if TYPE_CHECKING:
 
     def register_fake(fn):
@@ -47,7 +51,7 @@ def paged_attention_v1(
     blocksparse_block_size: int = 64,
     blocksparse_head_sliding_step: int = 0,
 ) -> None:
-    torch.ops._C.paged_attention_v1(
+    get_ops().paged_attention_v1(
         out,
         query,
         key_cache,
@@ -94,7 +98,7 @@ def paged_attention_v2(
     blocksparse_block_size: int = 64,
     blocksparse_head_sliding_step: int = 0,
 ) -> None:
-    torch.ops._C.paged_attention_v2(
+    get_ops().paged_attention_v2(
         out,
         exp_sum,
         max_logits,
@@ -174,7 +178,7 @@ def mla_decode_kvcache_cpu(
     block_tables: torch.Tensor,
     seq_lens: torch.Tensor,
 ) -> None:
-    torch.ops._C_cpu.mla_decode_kvcache(
+    get_cpu_ops().mla_decode_kvcache(
         out, query, kv_cache, scale, block_tables, seq_lens
     )
 
@@ -188,7 +192,7 @@ def merge_attn_states(
     suffix_lse: torch.Tensor,
     output_lse: torch.Tensor | None = None,
 ) -> None:
-    torch.ops._C.merge_attn_states(
+    get_ops().merge_attn_states(
         output, output_lse, prefix_output, prefix_lse, suffix_output, suffix_lse
     )
 
@@ -232,7 +236,7 @@ def convert_vertical_slash_indexes(
         device=q_seqlens.device,
     )
 
-    torch.ops._C.convert_vertical_slash_indexes(
+    get_ops().convert_vertical_slash_indexes(
         block_count,
         block_offset,
         column_count,
@@ -291,7 +295,7 @@ def convert_vertical_slash_indexes_mergehead(
         device=q_seqlens.device,
     )
 
-    torch.ops._C.convert_vertical_slash_indexes_mergehead(
+    get_ops().convert_vertical_slash_indexes_mergehead(
         block_count,
         block_offset,
         column_count,
@@ -319,7 +323,7 @@ def rotary_embedding(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    torch.ops._C.rotary_embedding(
+    get_ops().rotary_embedding(
         positions, query, key, head_size, cos_sin_cache, is_neox
     )
 
@@ -328,13 +332,13 @@ def rotary_embedding(
 def rms_norm(
     out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, epsilon: float
 ) -> None:
-    torch.ops._C.rms_norm(out, input, weight, epsilon)
+    get_ops().rms_norm(out, input, weight, epsilon)
 
 
 def fused_add_rms_norm(
     input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, epsilon: float
 ) -> None:
-    torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
+    get_ops().fused_add_rms_norm(input, residual, weight, epsilon)
 
 
 def fused_qk_norm_rope(
@@ -350,7 +354,7 @@ def fused_qk_norm_rope(
     is_neox: bool,
     position_ids: torch.Tensor,
 ) -> None:
-    torch.ops._C.fused_qk_norm_rope(
+    get_ops().fused_qk_norm_rope(
         qkv,
         num_heads_q,
         num_heads_k,
@@ -387,7 +391,7 @@ def apply_repetition_penalties_cuda(
     output_mask: torch.Tensor,
     repetition_penalties: torch.Tensor,
 ) -> None:
-    torch.ops._C.apply_repetition_penalties_(
+    get_ops().apply_repetition_penalties_(
         logits, prompt_mask, output_mask, repetition_penalties
     )
 
@@ -430,7 +434,7 @@ def rms_norm_dynamic_per_token_quant(
         (input.numel() // input.shape[-1], 1), device=input.device, dtype=torch.float32
     )
 
-    torch.ops._C.rms_norm_dynamic_per_token_quant(
+    get_ops().rms_norm_dynamic_per_token_quant(
         output, input, weight, scales, epsilon, scale_ub, residual
     )
     return output, scales
@@ -462,7 +466,7 @@ def rms_norm_per_block_quant(
             dtype=torch.float32,
         )
 
-    torch.ops._C.rms_norm_per_block_quant(
+    get_ops().rms_norm_per_block_quant(
         output,
         input,
         weight,
@@ -492,7 +496,7 @@ def awq_dequantize(
         )
 
         return awq_dequantize_triton(qweight, scales, zeros)
-    return torch.ops._C.awq_dequantize(qweight, scales, zeros, split_k_iters, thx, thy)
+    return get_ops().awq_dequantize(qweight, scales, zeros, split_k_iters, thx, thy)
 
 
 def awq_gemm(
@@ -506,7 +510,7 @@ def awq_gemm(
         from vllm.model_executor.layers.quantization.awq_triton import awq_gemm_triton
 
         return awq_gemm_triton(input, qweight, scales, qzeros, split_k_iters)
-    return torch.ops._C.awq_gemm(input, qweight, scales, qzeros, split_k_iters)
+    return get_ops().awq_gemm(input, qweight, scales, qzeros, split_k_iters)
 
 
 # gptq
@@ -520,7 +524,7 @@ def gptq_gemm(
     use_v2_format: bool,
     bit: int,
 ) -> torch.Tensor:
-    return torch.ops._C.gptq_gemm(
+    return get_ops().gptq_gemm(
         a,
         b_q_weight,
         b_gptq_qzeros,
@@ -532,7 +536,7 @@ def gptq_gemm(
     )
 
 
-if hasattr(torch.ops._C, "gptq_gemm"):
+if has_op("gptq_gemm"):
 
     @register_fake("_C::gptq_gemm")
     def _gptq_gemm_fake(
@@ -551,7 +555,7 @@ if hasattr(torch.ops._C, "gptq_gemm"):
 
 
 def gptq_shuffle(q_weight: torch.Tensor, q_perm: torch.Tensor, bit: int) -> None:
-    torch.ops._C.gptq_shuffle(q_weight, q_perm, bit)
+    get_ops().gptq_shuffle(q_weight, q_perm, bit)
 
 
 # marlin_24
@@ -566,12 +570,12 @@ def gptq_marlin_24_gemm(
     size_n: int,
     size_k: int,
 ) -> torch.Tensor:
-    return torch.ops._C.gptq_marlin_24_gemm(
+    return get_ops().gptq_marlin_24_gemm(
         a, b_q_weight, b_meta, b_scales, workspace, b_q_type.id, size_m, size_n, size_k
     )
 
 
-if hasattr(torch.ops._C, "gptq_marlin_24_gemm"):
+if has_op("gptq_marlin_24_gemm"):
 
     @register_fake("_C::gptq_marlin_24_gemm")
     def _gptq_marlin_24_gemm_fake(
@@ -700,7 +704,7 @@ if hasattr(torch.ops._C, "gptq_marlin_24_gemm"):
         return torch.empty_like(b, memory_format=torch.contiguous_format)
 
 
-if hasattr(torch.ops._C, "allspark_w8a16_gemm"):
+if has_op("allspark_w8a16_gemm"):
 
     @register_fake("_C::allspark_w8a16_gemm")
     def _allspark_w8a16_gemm_fake(
@@ -720,7 +724,7 @@ if hasattr(torch.ops._C, "allspark_w8a16_gemm"):
         return torch.empty((m, n), device=a.device, dtype=a.dtype)
 
 
-if hasattr(torch.ops._C, "ggml_dequantize"):
+if has_op("ggml_dequantize"):
 
     @register_fake("_C::ggml_dequantize")
     def _ggml_dequantize_fake(
@@ -767,7 +771,7 @@ if hasattr(torch.ops._C, "ggml_dequantize"):
         return torch.empty((tokens * top_k, row), dtype=torch.float16, device=W.device)
 
 
-if hasattr(torch.ops._C, "ggml_moe_a8_vec"):
+if has_op("ggml_moe_a8_vec"):
 
     @register_fake("_C::ggml_moe_a8_vec")
     def _ggml_moe_a8_vec_fake(
@@ -785,7 +789,7 @@ if hasattr(torch.ops._C, "ggml_moe_a8_vec"):
 
 # cutlass
 def cutlass_scaled_mm_supports_fp4(cuda_device_capability: int) -> bool:
-    return torch.ops._C.cutlass_scaled_mm_supports_fp4(cuda_device_capability)
+    return get_ops().cutlass_scaled_mm_supports_fp4(cuda_device_capability)
 
 
 def cutlass_blockwise_scaled_grouped_mm(
@@ -797,7 +801,7 @@ def cutlass_blockwise_scaled_grouped_mm(
     problem_sizes: torch.Tensor,
     expert_offsets: torch.Tensor,
 ):
-    torch.ops._C.cutlass_blockwise_scaled_grouped_mm(
+    get_ops().cutlass_blockwise_scaled_grouped_mm(
         output, a, b, scales_a, scales_b, problem_sizes, expert_offsets
     )
 
@@ -813,16 +817,16 @@ def cutlass_scaled_fp4_mm(
     assert a.ndim == 2 and b.ndim == 2
     m, n = a.shape[0], b.shape[0]
     out = torch.empty((m, n), dtype=out_dtype, device=a.device)
-    torch.ops._C.cutlass_scaled_fp4_mm(out, a, b, block_scale_a, block_scale_b, alpha)
+    get_ops().cutlass_scaled_fp4_mm(out, a, b, block_scale_a, block_scale_b, alpha)
     return out
 
 
 def cutlass_scaled_mm_supports_fp8(cuda_device_capability: int) -> bool:
-    return torch.ops._C.cutlass_scaled_mm_supports_fp8(cuda_device_capability)
+    return get_ops().cutlass_scaled_mm_supports_fp8(cuda_device_capability)
 
 
 def cutlass_scaled_mm_supports_block_fp8(cuda_device_capability: int) -> bool:
-    return torch.ops._C.cutlass_scaled_mm_supports_block_fp8(cuda_device_capability)
+    return get_ops().cutlass_scaled_mm_supports_block_fp8(cuda_device_capability)
 
 
 def cutlass_scaled_mm(
@@ -871,7 +875,7 @@ def cutlass_scaled_mm(
         out = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
     else:
         out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
-        torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
+        get_ops().cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
 
     return out.view(*target_shape)
 
@@ -901,17 +905,17 @@ def cutlass_scaled_mm_azp(
     assert azp is None or azp.numel() == a.shape[0]
 
     out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
-    torch.ops._C.cutlass_scaled_mm_azp(out, a, b, scale_a, scale_b, azp_adj, azp, bias)
+    get_ops().cutlass_scaled_mm_azp(out, a, b, scale_a, scale_b, azp_adj, azp, bias)
     return out.view(*target_shape)
 
 
 def cutlass_sparse_scaled_mm_supported(cuda_device_capability: int) -> bool:
-    return torch.ops._C.cutlass_sparse_scaled_mm_supported(cuda_device_capability)
+    return get_ops().cutlass_sparse_scaled_mm_supported(cuda_device_capability)
 
 
 def cutlass_group_gemm_supported(cuda_device_capability: int) -> bool:
     try:
-        return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)
+        return get_ops().cutlass_group_gemm_supported(cuda_device_capability)
     except AttributeError:
         # Return False on non-CUDA platforms where it is not available
         return False
@@ -955,7 +959,7 @@ def cutlass_sparse_compress(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
     elemsPerMetaElem = 4
     assert a.shape[1] % (2 * elemsPerMetaElem) == 0
 
-    return torch.ops._C.cutlass_sparse_compress(a)
+    return get_ops().cutlass_sparse_compress(a)
 
 
 def cutlass_scaled_sparse_mm(
@@ -998,7 +1002,7 @@ def cutlass_scaled_sparse_mm(
     n = bt_nzs.shape[0]
     out = torch.empty((m, n), dtype=out_dtype, device=a.device)
 
-    torch.ops._C.cutlass_scaled_sparse_mm(
+    get_ops().cutlass_scaled_sparse_mm(
         out, a, bt_nzs, bt_meta, scale_a, scale_b, bias
     )
 
@@ -1040,7 +1044,7 @@ def get_cutlass_moe_mm_data(
                           computed with expert E is blockscale_offsets[E + 1] -
                           blockscale_offsets[E]
     """
-    return torch.ops._C.get_cutlass_moe_mm_data(
+    return get_ops().get_cutlass_moe_mm_data(
         topk_ids,
         expert_offsets,
         problem_sizes1,
@@ -1077,7 +1081,7 @@ def get_cutlass_moe_mm_problem_sizes(
                      A/B input swap optimization. If None (default), the swap
                      is selected automatically based on tensor sizes.
     """
-    return torch.ops._C.get_cutlass_moe_mm_problem_sizes(
+    return get_ops().get_cutlass_moe_mm_problem_sizes(
         topk_ids,
         problem_sizes1,
         problem_sizes2,
@@ -1127,7 +1131,7 @@ def get_cutlass_pplx_moe_mm_data(
                                       multiplication in two grouped MMs used in
                                       the fused MoE operation.
     """
-    return torch.ops._C.get_cutlass_pplx_moe_mm_data(
+    return get_ops().get_cutlass_pplx_moe_mm_data(
         expert_offsets,
         problem_sizes1,
         problem_sizes2,
@@ -1164,7 +1168,7 @@ def cutlass_moe_mm(
                      MMs used in the fused MoE operation.
     - a/b/c_strides: The data strides passed to grouped matrix multiplication.
     """
-    return torch.ops._C.cutlass_moe_mm(
+    return get_ops().cutlass_moe_mm(
         out_tensors,
         a_tensors,
         b_tensors,
@@ -1207,7 +1211,7 @@ def cutlass_fp4_moe_mm(
     - problem_sizes: MxNxK sizes of each expert's multiplication in two grouped
                      MMs used in the fused MoE operation.
     """
-    return torch.ops._C.cutlass_fp4_group_mm(
+    return get_ops().cutlass_fp4_group_mm(
         out_tensors,
         a_tensors,
         b_tensors,
@@ -1229,12 +1233,12 @@ def gptq_marlin_repack(
     num_bits: int,
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
-    return torch.ops._C.gptq_marlin_repack(
+    return get_ops().gptq_marlin_repack(
         b_q_weight, perm, size_k, size_n, num_bits, is_a_8bit
     )
 
 
-if hasattr(torch.ops._C, "gptq_marlin_repack"):
+if has_op("gptq_marlin_repack"):
 
     @register_fake("_C::gptq_marlin_repack")
     def _gptq_marlin_repack_fake(
@@ -1262,12 +1266,12 @@ def awq_marlin_repack(
     num_bits: int,
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
-    return torch.ops._C.awq_marlin_repack(
+    return get_ops().awq_marlin_repack(
         b_q_weight, size_k, size_n, num_bits, is_a_8bit
     )
 
 
-if hasattr(torch.ops._C, "awq_marlin_repack"):
+if has_op("awq_marlin_repack"):
 
     @register_fake("_C::awq_marlin_repack")
     def _awq_marlin_repack_fake(
@@ -1302,7 +1306,7 @@ def gptq_marlin_moe_repack(
         dtype=b_q_weight.dtype,
     )
     for e in range(num_experts):
-        output[e] = torch.ops._C.gptq_marlin_repack(
+        output[e] = get_ops().gptq_marlin_repack(
             b_q_weight[e], perm[e], size_k, size_n, num_bits, is_a_8bit
         )
     return output
@@ -1324,7 +1328,7 @@ def awq_marlin_moe_repack(
         dtype=b_q_weight.dtype,
     )
     for e in range(num_experts):
-        output[e] = torch.ops._C.awq_marlin_repack(
+        output[e] = get_ops().awq_marlin_repack(
             b_q_weight[e], size_k, size_n, num_bits, is_a_8bit
         )
     return output
@@ -1335,7 +1339,7 @@ def marlin_int4_fp8_preprocess(
     qzeros_or_none: torch.Tensor | None = None,
     inplace: bool = False,
 ):
-    return torch.ops._C.marlin_int4_fp8_preprocess(qweight, qzeros_or_none, inplace)
+    return get_ops().marlin_int4_fp8_preprocess(qweight, qzeros_or_none, inplace)
 
 
 def gptq_marlin_gemm(
@@ -1359,7 +1363,7 @@ def gptq_marlin_gemm(
     use_fp32_reduce: bool = False,
     is_zp_float: bool = False,
 ) -> torch.Tensor:
-    return torch.ops._C.gptq_marlin_gemm(
+    return get_ops().gptq_marlin_gemm(
         a,
         c,
         b_q_weight,
@@ -1392,7 +1396,7 @@ def machete_supported_schedules(
     token_scales_type: torch.dtype | None = None,
     out_type: torch.dtype | None = None,
 ) -> list[str]:
-    return torch.ops._C.machete_supported_schedules(
+    return get_ops().machete_supported_schedules(
         a_type,
         b_type.id,
         group_scales_type,
@@ -1416,7 +1420,7 @@ def machete_mm(
     a_token_scales: torch.Tensor | None = None,
     schedule: str | None = None,
 ) -> torch.Tensor:
-    return torch.ops._C.machete_mm(
+    return get_ops().machete_mm(
         a,
         b_q,
         b_type.id,
@@ -1436,7 +1440,7 @@ def machete_prepack_B(
     b_type: ScalarType,
     group_scales_type: torch.dtype | None,
 ) -> torch.Tensor:
-    return torch.ops._C.machete_prepack_B(
+    return get_ops().machete_prepack_B(
         b_q_weight, a_type, b_type.id, group_scales_type
     )
 
@@ -1453,7 +1457,7 @@ def cutlass_w4a8_mm(
     out_type: torch.dtype | None = None,
     maybe_schedule: str | None = None,
 ) -> torch.Tensor:
-    return torch.ops._C.cutlass_w4a8_mm(
+    return get_ops().cutlass_w4a8_mm(
         a,
         b_q,
         b_group_scales,
@@ -1466,11 +1470,11 @@ def cutlass_w4a8_mm(
 
 
 def cutlass_pack_scale_fp8(scales: torch.Tensor) -> torch.Tensor:
-    return torch.ops._C.cutlass_pack_scale_fp8(scales)
+    return get_ops().cutlass_pack_scale_fp8(scales)
 
 
 def cutlass_encode_and_reorder_int4b(b: torch.Tensor) -> torch.Tensor:
-    return torch.ops._C.cutlass_encode_and_reorder_int4b(b)
+    return get_ops().cutlass_encode_and_reorder_int4b(b)
 
 
 def cutlass_w4a8_moe_mm(
@@ -1521,7 +1525,7 @@ def cutlass_w4a8_moe_mm(
     Returns:
         out_tensors updated in-place with the dequantized INT4xFP8 grouped GEMM result.
     """
-    return torch.ops._C.cutlass_w4a8_moe_mm(
+    return get_ops().cutlass_w4a8_moe_mm(
         out_tensors,
         a_tensors,
         b_tensors,
@@ -1542,10 +1546,10 @@ def cutlass_w4a8_moe_mm(
 def cutlass_encode_and_reorder_int4b_grouped(
     b_tensors: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    return torch.ops._C.cutlass_encode_and_reorder_int4b_grouped(b_tensors)
+    return get_ops().cutlass_encode_and_reorder_int4b_grouped(b_tensors)
 
 
-if hasattr(torch.ops._C, "permute_cols"):
+if has_op("permute_cols"):
 
     @register_fake("_C::permute_cols")
     def _permute_cols_fake(a: torch.Tensor, perm: torch.Tensor) -> torch.Tensor:
@@ -1553,7 +1557,7 @@ if hasattr(torch.ops._C, "permute_cols"):
 
 
 def permute_cols(a: torch.Tensor, perm: torch.Tensor) -> torch.Tensor:
-    return torch.ops._C.permute_cols(a, perm)
+    return get_ops().permute_cols(a, perm)
 
 
 # fp4
@@ -1607,7 +1611,7 @@ def scaled_fp4_quant(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 
-    torch.ops._C.scaled_fp4_quant(output, input, output_scale, input_global_scale)
+    get_ops().scaled_fp4_quant(output, input, output_scale, input_global_scale)
     output_scale = output_scale.view(torch.float8_e4m3fn)
     return output, output_scale
 
@@ -1662,7 +1666,7 @@ def scaled_fp4_experts_quant(
         dtype=torch.int32,
         device=input_tensor.device,
     )
-    torch.ops._C.scaled_fp4_experts_quant(
+    get_ops().scaled_fp4_experts_quant(
         output,
         output_scales,
         input_tensor,
@@ -1722,15 +1726,15 @@ def scaled_fp8_quant(
     if scale is None:
         if use_per_token_if_dynamic:
             scale = torch.empty((shape[0], 1), device=input.device, dtype=torch.float32)
-            torch.ops._C.dynamic_per_token_scaled_fp8_quant(
+            get_ops().dynamic_per_token_scaled_fp8_quant(
                 output, input, scale, scale_ub
             )
         else:
             scale = torch.empty(1, device=input.device, dtype=torch.float32)
-            torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
+            get_ops().dynamic_scaled_fp8_quant(output, input, scale)
     else:
         assert scale.numel() == 1, f"{scale.shape}"
-        torch.ops._C.static_scaled_fp8_quant(output, input, scale)
+        get_ops().static_scaled_fp8_quant(output, input, scale)
 
     return output, scale
 
@@ -1775,7 +1779,7 @@ def allspark_repack_weight(
             (1, N_32align), device=zero_point.device, dtype=zero_point.dtype
         )
 
-    torch.ops._C.rearrange_kn_weight_as_n32k16_order(
+    get_ops().rearrange_kn_weight_as_n32k16_order(
         qweight,
         scale,
         zero_point,
@@ -1804,7 +1808,7 @@ def allspark_w8a16_gemm(
     has_zp: bool,
     n32k16_reorder: bool,
 ) -> torch.Tensor:
-    return torch.ops._C.allspark_w8a16_gemm(
+    return get_ops().allspark_w8a16_gemm(
         a,
         b_qweight,
         b_scales,
@@ -1846,7 +1850,7 @@ def scaled_int8_quant(
         assert symmetric == (azp is None), (
             "azp must only be provided for asymmetric quantization."
         )
-        torch.ops._C.static_scaled_int8_quant(output, input, scale, azp)
+        get_ops().static_scaled_int8_quant(output, input, scale, azp)
         return output, scale, azp
 
     # dynamic-per-token quantization.
@@ -1854,7 +1858,7 @@ def scaled_int8_quant(
         (input.numel() // input.shape[-1], 1), device=input.device, dtype=torch.float32
     )
     input_azp = None if symmetric else torch.empty_like(input_scales, dtype=torch.int32)
-    torch.ops._C.dynamic_scaled_int8_quant(
+    get_ops().dynamic_scaled_int8_quant(
         output, input.contiguous(), input_scales, input_azp
     )
     return output, input_scales, input_azp
@@ -1864,7 +1868,7 @@ def scaled_int8_quant(
 def ggml_dequantize(
     W: torch.Tensor, quant_type: int, m: int, n: int, dtype: torch.dtype | None
 ) -> torch.Tensor:
-    return torch.ops._C.ggml_dequantize(W, quant_type, m, n, dtype)
+    return get_ops().ggml_dequantize(W, quant_type, m, n, dtype)
 
 
 def ggml_mul_mat_vec_a8(
@@ -1873,7 +1877,7 @@ def ggml_mul_mat_vec_a8(
     quant_type: int,
     row: int,
 ) -> torch.Tensor:
-    return torch.ops._C.ggml_mul_mat_vec_a8(W, X, quant_type, row)
+    return get_ops().ggml_mul_mat_vec_a8(W, X, quant_type, row)
 
 
 def ggml_mul_mat_a8(
@@ -1882,7 +1886,7 @@ def ggml_mul_mat_a8(
     quant_type: int,
     row: int,
 ) -> torch.Tensor:
-    return torch.ops._C.ggml_mul_mat_a8(W, X, quant_type, row)
+    return get_ops().ggml_mul_mat_a8(W, X, quant_type, row)
 
 
 def ggml_moe_a8(
@@ -1896,7 +1900,7 @@ def ggml_moe_a8(
     top_k: int,
     tokens: int,
 ) -> torch.Tensor:
-    return torch.ops._C.ggml_moe_a8(
+    return get_ops().ggml_moe_a8(
         X,
         W,
         sorted_token_ids,
@@ -1918,11 +1922,11 @@ def ggml_moe_a8_vec(
     row: torch.SymInt,
     tokens: torch.SymInt,
 ) -> torch.Tensor:
-    return torch.ops._C.ggml_moe_a8_vec(X, W, topk_ids, top_k, quant_type, row, tokens)
+    return get_ops().ggml_moe_a8_vec(X, W, topk_ids, top_k, quant_type, row, tokens)
 
 
 def ggml_moe_get_block_size(quant_type: int) -> int:
-    return torch.ops._C.ggml_moe_get_block_size(quant_type)
+    return get_ops().ggml_moe_get_block_size(quant_type)
 
 
 # mamba
@@ -1946,7 +1950,7 @@ def selective_scan_fwd(
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
 ):
-    torch.ops._C.selective_scan_fwd(
+    get_ops().selective_scan_fwd(
         u,
         delta,
         A,
@@ -2563,7 +2567,7 @@ def get_flash_mla_metadata(
         tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), dtype torch.int32.
         num_splits: (batch_size + 1), dtype torch.int32.
     """
-    return torch.ops._C.get_flash_mla_metadata(
+    return get_ops().get_flash_mla_metadata(
         cache_seqlens, num_heads_per_head_k, num_heads_k
     )
 
@@ -2597,7 +2601,7 @@ def flash_mla_with_kvcache(
     """
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
-    out, softmax_lse = torch.ops._C.flash_mla_fwd_kvcache(
+    out, softmax_lse = get_ops().flash_mla_fwd_kvcache(
         q,
         k_cache,
         None,
@@ -2624,7 +2628,7 @@ def sm100_cutlass_mla_decode(
     scale: float,
     num_kv_splits: int,
 ) -> torch.Tensor:
-    torch.ops._C.sm100_cutlass_mla_decode(
+    get_ops().sm100_cutlass_mla_decode(
         out,
         lse,
         q_nope,
@@ -2642,12 +2646,12 @@ def sm100_cutlass_mla_decode(
 def sm100_cutlass_mla_get_workspace_size(
     max_seq_len: int, num_batches: int, sm_count: int, num_kv_splits: int
 ) -> int:
-    return torch.ops._C.sm100_cutlass_mla_get_workspace_size(
+    return get_ops().sm100_cutlass_mla_get_workspace_size(
         max_seq_len, num_batches, sm_count, num_kv_splits
     )
 
 
-if hasattr(torch.ops._C, "weight_packed_linear"):
+if has_op("weight_packed_linear"):
 
     @register_fake("_C::weight_packed_linear")
     def weight_packed_linear_fake(
@@ -2661,7 +2665,7 @@ if hasattr(torch.ops._C, "weight_packed_linear"):
         )
 
 
-if hasattr(torch.ops._C, "fused_experts_cpu"):
+if has_op("fused_experts_cpu"):
 
     @register_fake("_C::fused_experts_cpu")
     def fused_experts_cpu_fake(
@@ -2683,7 +2687,7 @@ if hasattr(torch.ops._C, "fused_experts_cpu"):
         return torch.empty_like(hidden_states)
 
 
-if hasattr(torch.ops._C, "int8_scaled_mm_with_quant"):
+if has_op("int8_scaled_mm_with_quant"):
 
     @register_fake("_C::int8_scaled_mm_with_quant")
     def int8_scaled_mm_with_quant_fake(
@@ -2707,14 +2711,14 @@ class CPUDNNLGEMMHandler:
 
     def __del__(self):
         if self.handler is not None:
-            torch.ops._C.release_dnnl_matmul_handler(self.handler)
+            get_ops().release_dnnl_matmul_handler(self.handler)
 
 
-_supports_onednn = bool(hasattr(torch.ops._C, "create_onednn_mm_handler"))
+_supports_onednn = bool(has_op("create_onednn_mm_handler"))
 
 
 def is_onednn_acl_supported():
-    return torch.ops._C.is_onednn_acl_supported()
+    return get_ops().is_onednn_acl_supported()
 
 
 def create_onednn_mm(
@@ -2723,7 +2727,7 @@ def create_onednn_mm(
 ) -> CPUDNNLGEMMHandler:
     handler = CPUDNNLGEMMHandler()
     handler.k, handler.n = weight.size()
-    handler.handler = torch.ops._C.create_onednn_mm_handler(
+    handler.handler = get_ops().create_onednn_mm_handler(
         weight, primitive_cache_size
     )
     return handler
@@ -2735,7 +2739,7 @@ def onednn_mm(
     bias: torch.Tensor | None,
 ) -> torch.Tensor:
     output = torch.empty((*x.shape[0:-1], dnnl_handler.n), dtype=x.dtype)
-    torch.ops._C.onednn_mm(
+    get_ops().onednn_mm(
         output, x.reshape(-1, dnnl_handler.k), bias, dnnl_handler.handler
     )
 
@@ -2752,7 +2756,7 @@ def create_onednn_scaled_mm(
 ) -> CPUDNNLGEMMHandler:
     handler = CPUDNNLGEMMHandler()
     handler.k, handler.n = weight.size()
-    handler.handler = torch.ops._C.create_onednn_scaled_mm_handler(
+    handler.handler = get_ops().create_onednn_scaled_mm_handler(
         weight, weight_scales, output_type, dynamic_quant, use_azp, primitive_cache_size
     )
     return handler
@@ -2786,13 +2790,13 @@ def onednn_scaled_int8_quant(
         assert symmetric == (azp is None), (
             "azp must only be provided for asymmetric quantization."
         )
-        torch.ops._C.static_scaled_int8_quant(output, input, scale, azp)
+        get_ops().static_scaled_int8_quant(output, input, scale, azp)
         return output, scale, azp
 
     # dynamic-per-token quantization.
     input_scales = torch.empty((token_num, 1), device=input.device, dtype=torch.float32)
     input_azp = None if symmetric else torch.empty_like(input_scales, dtype=torch.int32)
-    torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales, input_azp)
+    get_ops().dynamic_scaled_int8_quant(output, input, input_scales, input_azp)
     return output, input_scales, input_azp
 
 
@@ -2805,7 +2809,7 @@ def onednn_scaled_mm(
     input_zp_adj: torch.Tensor | None,
     bias: torch.Tensor | None,
 ) -> torch.Tensor:
-    torch.ops._C.onednn_scaled_mm(
+    get_ops().onednn_scaled_mm(
         output, x, input_scale, input_zp, input_zp_adj, bias, dnnl_handler.handler
     )
 
@@ -2825,7 +2829,7 @@ def cpu_attn_get_scheduler_metadata(
     isa: str,
     enable_kv_split: bool,
 ) -> torch.Tensor:
-    sheduler_metadata = torch.ops._C.get_scheduler_metadata(
+    sheduler_metadata = get_ops().get_scheduler_metadata(
         num_reqs,
         num_heads,
         num_kv_heads,
@@ -2849,7 +2853,7 @@ def cpu_attn_reshape_and_cache(
     slot_mapping: torch.Tensor,
     isa: str,
 ) -> None:
-    torch.ops._C.cpu_attn_reshape_and_cache(
+    get_ops().cpu_attn_reshape_and_cache(
         key,
         value,
         key_cache,
@@ -2875,7 +2879,7 @@ def cpu_attention_with_kv_cache(
     scheduler_metadata: torch.Tensor,
     s_aux: torch.Tensor | None,
 ) -> None:
-    torch.ops._C.cpu_attention_with_kv_cache(
+    get_ops().cpu_attention_with_kv_cache(
         query,
         key_cache,
         value_cache,
@@ -2905,7 +2909,7 @@ def cpu_gemm_wna16(
     isa_hint: str,
 ) -> torch.Tensor:
     output = torch.empty((input.size(0), scales.size(1)), dtype=input.dtype)
-    torch.ops._C.cpu_gemm_wna16(
+    get_ops().cpu_gemm_wna16(
         input,
         q_weight,
         output,
@@ -2924,7 +2928,7 @@ def cpu_prepack_moe_weight(
     isa: str,
 ) -> torch.Tensor:
     output = torch.empty_like(weight)
-    torch.ops._C.prepack_moe_weight(weight, output, isa)
+    get_ops().prepack_moe_weight(weight, output, isa)
     return output
 
 
@@ -2940,7 +2944,7 @@ def cpu_fused_moe(
     isa: str,
 ) -> torch.Tensor:
     output = torch.empty_like(input)
-    torch.ops._C.cpu_fused_moe(
+    get_ops().cpu_fused_moe(
         output,
         input,
         w13,
@@ -3106,10 +3110,10 @@ def hadacore_transform(x: torch.Tensor, inplace: bool = True) -> torch.Tensor:
     :param inplace: modify value in place
     :return: value after transformation
     """
-    return torch.ops._C.hadacore_transform(x, inplace)
+    return get_ops().hadacore_transform(x, inplace)
 
 
-if hasattr(torch.ops._C, "hadacore_transform"):
+if has_op("hadacore_transform"):
 
     @register_fake("_C::hadacore_transform")
     def _hadacore_transform_fake(x: torch.Tensor, inplace: bool) -> torch.Tensor:

--- a/vllm/_ops_dispatch.py
+++ b/vllm/_ops_dispatch.py
@@ -1,0 +1,199 @@
+"""
+Dynamic dispatcher for CPU extension operations.
+
+This module provides a unified interface to torch.ops regardless of which
+CPU extension is loaded (_C for AVX2 or _C_avx512 for AVX512).
+
+The dispatcher detects which extension is available and routes calls
+to the correct namespace.
+
+Background:
+-----------
+The cpu-build-dispatcher branch builds two separate .so files:
+- _C.so (AVX2 build) -> registers to torch.ops._C
+- _C_avx512.so (AVX512 build) -> registers to torch.ops._C_avx512
+
+At runtime, only ONE extension is loaded based on CPU detection.
+This dispatcher routes calls to whichever extension is available.
+"""
+
+import torch
+from functools import lru_cache
+from typing import Any, Optional
+
+
+@lru_cache(maxsize=1)
+def _detect_cpu_extension() -> str:
+    """
+    Detect which CPU extension is loaded.
+
+    Returns:
+        "_C_avx512" if AVX512 extension loaded
+        "_C" if AVX2 extension loaded (or CUDA build with _C)
+        "" if no extension detected
+    """
+    # Check for AVX512 extension first (more specific)
+    if hasattr(torch.ops, '_C_avx512'):
+        # Verify it has actual CPU ops registered (not empty)
+        if hasattr(torch.ops._C_avx512, 'silu_and_mul'):
+            return "_C_avx512"
+
+    # Check for AVX2/default extension
+    if hasattr(torch.ops, '_C'):
+        # For CPU builds, check for a CPU-specific op
+        # For CUDA builds, _C will have CUDA ops
+        if hasattr(torch.ops._C, 'silu_and_mul'):
+            return "_C"
+
+    # No CPU extension loaded
+    return ""
+
+
+@lru_cache(maxsize=1)
+def get_ops():
+    """
+    Get the correct torch.ops module for CPU operations.
+
+    Returns:
+        torch.ops._C_avx512 or torch.ops._C depending on loaded extension
+
+    Note:
+        Falls back to torch.ops._C for CUDA builds where ops are registered there.
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        return torch.ops._C_avx512
+    elif ext == "_C":
+        return torch.ops._C
+    else:
+        # Fall back to _C (for CUDA builds or if detection fails)
+        return torch.ops._C
+
+
+@lru_cache(maxsize=1)
+def get_utils():
+    """
+    Get the correct torch.ops utils module.
+
+    Returns:
+        torch.ops._C_avx512_utils or torch.ops._C_utils
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        if hasattr(torch.ops, '_C_avx512_utils'):
+            return torch.ops._C_avx512_utils
+    if hasattr(torch.ops, '_C_utils'):
+        return torch.ops._C_utils
+    # Return None if no utils module found (caller should handle)
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_cpu_ops():
+    """
+    Get the correct torch.ops CPU-specific module (_C_cpu or _C_avx512_cpu).
+
+    Returns:
+        The CPU ops module, or None if not available
+    """
+    ext = _detect_cpu_extension()
+    if ext == "_C_avx512":
+        if hasattr(torch.ops, '_C_avx512_cpu'):
+            return torch.ops._C_avx512_cpu
+    if hasattr(torch.ops, '_C_cpu'):
+        return torch.ops._C_cpu
+    return None
+
+
+def has_op(op_name: str) -> bool:
+    """
+    Check if an operation is available in the loaded extension.
+
+    Args:
+        op_name: Name of the operation (e.g., "onednn_mm")
+
+    Returns:
+        True if operation exists, False otherwise
+    """
+    try:
+        ops = get_ops()
+        return hasattr(ops, op_name)
+    except Exception:
+        return False
+
+
+def get_op(op_name: str) -> Optional[Any]:
+    """
+    Get an operation by name, or None if not available.
+
+    Args:
+        op_name: Name of the operation
+
+    Returns:
+        The operation callable, or None if not found
+    """
+    try:
+        ops = get_ops()
+        return getattr(ops, op_name, None)
+    except Exception:
+        return None
+
+
+class _OpsProxy:
+    """
+    Proxy object that forwards attribute access to the correct ops module.
+
+    Usage:
+        from vllm._ops_dispatch import ops
+        ops.silu_and_mul(out, x)  # Automatically routes to correct extension
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        ops = get_ops()
+        return getattr(ops, name)
+
+
+class _UtilsProxy:
+    """
+    Proxy object that forwards attribute access to the correct utils module.
+
+    Usage:
+        from vllm._ops_dispatch import utils
+        utils.init_cpu_threads_env(cpu_ids)
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        utils_module = get_utils()
+        if utils_module is None:
+            raise RuntimeError("No CPU utils extension loaded")
+        return getattr(utils_module, name)
+
+
+class _CpuOpsProxy:
+    """
+    Proxy object that forwards attribute access to the correct CPU ops module.
+
+    Usage:
+        from vllm._ops_dispatch import cpu_ops
+        cpu_ops.mla_decode_kvcache(...)
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        cpu_ops_module = get_cpu_ops()
+        if cpu_ops_module is None:
+            raise RuntimeError("No CPU ops extension loaded")
+        return getattr(cpu_ops_module, name)
+
+
+# Global proxy instances for convenient access
+ops = _OpsProxy()
+utils = _UtilsProxy()
+cpu_ops = _CpuOpsProxy()
+
+
+def clear_cache():
+    """Clear cached extension detection (useful for testing)."""
+    _detect_cpu_extension.cache_clear()
+    get_ops.cache_clear()
+    get_utils.cache_clear()
+    get_cpu_ops.cache_clear()

--- a/vllm/compilation/activation_quant_fusion.py
+++ b/vllm/compilation/activation_quant_fusion.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 from torch._inductor.pattern_matcher import (
     PatternMatcherPass,
@@ -37,8 +37,8 @@ SILU_MUL_OP = get_ops().silu_and_mul.default
 FUSED_OPS: dict[QuantKey, OpOverload] = {
     kFp8StaticTensorSym: get_ops().silu_and_mul_quant.default,  # noqa: E501
 }
-silu_and_mul_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
-    torch.ops._C, "silu_and_mul_nvfp4_quant"
+silu_and_mul_nvfp4_quant_supported = current_platform.is_cuda() and has_op(
+    "silu_and_mul_nvfp4_quant"
 )
 if silu_and_mul_nvfp4_quant_supported:
     FUSED_OPS[kNvfp4Quant] = get_ops().silu_and_mul_nvfp4_quant.default  # noqa: E501

--- a/vllm/compilation/activation_quant_fusion.py
+++ b/vllm/compilation/activation_quant_fusion.py
@@ -4,6 +4,7 @@
 from abc import ABC, abstractmethod
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 from torch._inductor.pattern_matcher import (
     PatternMatcherPass,
@@ -31,16 +32,16 @@ logger = init_logger(__name__)
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
 
-SILU_MUL_OP = torch.ops._C.silu_and_mul.default
+SILU_MUL_OP = get_ops().silu_and_mul.default
 
 FUSED_OPS: dict[QuantKey, OpOverload] = {
-    kFp8StaticTensorSym: torch.ops._C.silu_and_mul_quant.default,  # noqa: E501
+    kFp8StaticTensorSym: get_ops().silu_and_mul_quant.default,  # noqa: E501
 }
 silu_and_mul_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
     torch.ops._C, "silu_and_mul_nvfp4_quant"
 )
 if silu_and_mul_nvfp4_quant_supported:
-    FUSED_OPS[kNvfp4Quant] = torch.ops._C.silu_and_mul_nvfp4_quant.default  # noqa: E501
+    FUSED_OPS[kNvfp4Quant] = get_ops().silu_and_mul_nvfp4_quant.default  # noqa: E501
 
 
 class ActivationQuantPattern(ABC):

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -3,6 +3,7 @@
 from importlib.util import find_spec
 
 import torch
+from vllm._ops_dispatch import get_ops
 import torch._inductor.pattern_matcher as pm
 import torch.fx as fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -46,7 +47,7 @@ else:
 logger = init_logger(__name__)
 
 if hasattr(torch.ops._C, "scaled_fp4_quant"):
-    STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.default
+    STATIC_FP4_QUANT_OP = get_ops().scaled_fp4_quant.default
 
 
 class BasePattern:
@@ -280,7 +281,7 @@ class CutlassScaledMMReduceScatterPattern(BasePattern):
             cutlass_mm_output: torch.Tensor,
         ) -> torch.Tensor:
             cutlass_scaled_mm = torch.ops.higher_order.auto_functionalized(
-                torch.ops._C.cutlass_scaled_mm.default,
+                get_ops().cutlass_scaled_mm.default,
                 out=cutlass_mm_output,
                 a=input,
                 b=weight,
@@ -362,7 +363,7 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
             )
 
             cutlass_scaled_mm = torch.ops.higher_order.auto_functionalized(
-                torch.ops._C.cutlass_scaled_mm.default,
+                get_ops().cutlass_scaled_mm.default,
                 out=output,
                 a=all_gather,
                 b=weight,

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -3,7 +3,7 @@
 from importlib.util import find_spec
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 import torch._inductor.pattern_matcher as pm
 import torch.fx as fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -46,7 +46,7 @@ else:
 
 logger = init_logger(__name__)
 
-if hasattr(torch.ops._C, "scaled_fp4_quant"):
+if has_op("scaled_fp4_quant"):
     STATIC_FP4_QUANT_OP = get_ops().scaled_fp4_quant.default
 
 

--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -5,6 +5,7 @@ import operator
 from collections.abc import Iterable
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 
 from vllm.logger import init_logger
@@ -44,7 +45,7 @@ class FixFunctionalizationPass(VllmInductorPass):
             kwargs = node.kwargs
             at_target = node.args[0]
 
-            if at_target == torch.ops._C.rotary_embedding.default:
+            if at_target == get_ops().rotary_embedding.default:
                 query = kwargs["query"]
                 key = kwargs["key"]
                 getitem_nodes = self.getitem_users(node)
@@ -88,18 +89,18 @@ class FixFunctionalizationPass(VllmInductorPass):
                     self.defunctionalize(graph, node, mutated_args)
 
             # rms_norm replacements avoid the most copies for LLaMa.
-            elif at_target == torch.ops._C.fused_add_rms_norm.default:
+            elif at_target == get_ops().fused_add_rms_norm.default:
                 mutated_args = {1: "input", 2: "residual"}
                 self.defunctionalize(graph, node, mutated_args)
-            elif at_target == torch.ops._C.fused_add_rms_norm_static_fp8_quant.default:  # noqa: E501
+            elif at_target == get_ops().fused_add_rms_norm_static_fp8_quant.default:  # noqa: E501
                 mutated_args = {1: "result", 2: "residual"}
                 self.defunctionalize(graph, node, mutated_args)
-            elif at_target == torch.ops._C.rms_norm_dynamic_per_token_quant.default:  # noqa: E501
+            elif at_target == get_ops().rms_norm_dynamic_per_token_quant.default:  # noqa: E501
                 mutated_args = {1: "result", 2: "scale", 3: "residual"}
                 self.defunctionalize(graph, node, mutated_args)
             elif at_target in [
-                torch.ops._C.rms_norm.default,
-                torch.ops._C.rms_norm_static_fp8_quant.default,
+                get_ops().rms_norm.default,
+                get_ops().rms_norm_static_fp8_quant.default,
             ]:
                 mutated_args = {1: "result"}
                 self.defunctionalize(graph, node, mutated_args)
@@ -119,19 +120,19 @@ class FixFunctionalizationPass(VllmInductorPass):
             # For some reason we need to specify the args for both
             # silu_and_mul and silu_and_mul_quant. The kwargs
             # pathway gets the wrong answer.
-            elif at_target == torch.ops._C.silu_and_mul.default:
+            elif at_target == get_ops().silu_and_mul.default:
                 mutated_args = {1: "result"}
                 self.defunctionalize(
                     graph, node, mutated_args, args=("result", "input")
                 )
-            elif at_target == torch.ops._C.silu_and_mul_quant.default:
+            elif at_target == get_ops().silu_and_mul_quant.default:
                 mutated_args = {1: "result"}
                 self.defunctionalize(
                     graph, node, mutated_args, args=("result", "input", "scale")
                 )
             elif (
                 hasattr(torch.ops._C, "silu_and_mul_nvfp4_quant")
-                and at_target == torch.ops._C.silu_and_mul_nvfp4_quant.default
+                and at_target == get_ops().silu_and_mul_nvfp4_quant.default
             ):
                 mutated_args = {1: "result", 2: "result_block_scale"}
                 self.defunctionalize(
@@ -146,7 +147,7 @@ class FixFunctionalizationPass(VllmInductorPass):
                     ),
                 )
             # Defunctionalize fused_qk_norm_rope to remove higher-order wrapper.
-            elif at_target == torch.ops._C.fused_qk_norm_rope.default:
+            elif at_target == get_ops().fused_qk_norm_rope.default:
                 mutated_args = {1: "qkv"}
                 args = (
                     "qkv",

--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -5,7 +5,7 @@ import operator
 from collections.abc import Iterable
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 
 from vllm.logger import init_logger
@@ -131,7 +131,7 @@ class FixFunctionalizationPass(VllmInductorPass):
                     graph, node, mutated_args, args=("result", "input", "scale")
                 )
             elif (
-                hasattr(torch.ops._C, "silu_and_mul_nvfp4_quant")
+                has_op("silu_and_mul_nvfp4_quant")
                 and at_target == get_ops().silu_and_mul_nvfp4_quant.default
             ):
                 mutated_args = {1: "result", 2: "result_block_scale"}

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -3,6 +3,7 @@
 from typing import Any, NamedTuple
 
 import torch
+from vllm._ops_dispatch import get_ops
 import torch._inductor.pattern_matcher as pm
 from torch import fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -54,19 +55,19 @@ def empty_i64(*args, **kwargs):
     return torch.empty(*args, **kwargs, dtype=torch.int64, device="cuda")
 
 
-RMS_OP = torch.ops._C.rms_norm.default
-RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
+RMS_OP = get_ops().rms_norm.default
+RMS_ADD_OP = get_ops().fused_add_rms_norm.default
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {
-    kFp8StaticTensorSym: torch.ops._C.static_scaled_fp8_quant.default,  # noqa: E501
-    kFp8DynamicTensorSym: torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa: E501
-    kFp8DynamicTokenSym: torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
+    kFp8StaticTensorSym: get_ops().static_scaled_fp8_quant.default,  # noqa: E501
+    kFp8DynamicTensorSym: get_ops().dynamic_scaled_fp8_quant.default,  # noqa: E501
+    kFp8DynamicTokenSym: get_ops().dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
 if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
-    QUANT_OPS[kNvfp4Quant] = torch.ops._C.scaled_fp4_quant.default
+    QUANT_OPS[kNvfp4Quant] = get_ops().scaled_fp4_quant.default
 if current_platform.is_cuda():
-    QUANT_OPS[kFp8Dynamic128Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
-    QUANT_OPS[kFp8Dynamic64Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
+    QUANT_OPS[kFp8Dynamic128Sym] = get_ops().per_token_group_fp8_quant.default  # noqa: E501
+    QUANT_OPS[kFp8Dynamic64Sym] = get_ops().per_token_group_fp8_quant.default  # noqa: E501
 
 
 class FusedRMSQuantKey(NamedTuple):
@@ -89,28 +90,28 @@ class FusedRMSQuantKey(NamedTuple):
 FUSED_OPS: dict[FusedRMSQuantKey, OpOverload] = {
     FusedRMSQuantKey(
         kFp8StaticTensorSym, False
-    ): torch.ops._C.rms_norm_static_fp8_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_static_fp8_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8StaticTensorSym, True
-    ): torch.ops._C.fused_add_rms_norm_static_fp8_quant.default,  # noqa: E501
+    ): get_ops().fused_add_rms_norm_static_fp8_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8DynamicTokenSym, False
-    ): torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_dynamic_per_token_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8DynamicTokenSym, True
-    ): torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_dynamic_per_token_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8Dynamic128Sym, False
-    ): torch.ops._C.rms_norm_per_block_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_per_block_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8Dynamic128Sym, True
-    ): torch.ops._C.rms_norm_per_block_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_per_block_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8Dynamic64Sym, False
-    ): torch.ops._C.rms_norm_per_block_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_per_block_quant.default,  # noqa: E501
     FusedRMSQuantKey(
         kFp8Dynamic64Sym, True
-    ): torch.ops._C.rms_norm_per_block_quant.default,  # noqa: E501
+    ): get_ops().rms_norm_per_block_quant.default,  # noqa: E501
 }
 
 

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -3,7 +3,7 @@
 from typing import Any, NamedTuple
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 import torch._inductor.pattern_matcher as pm
 from torch import fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -63,7 +63,7 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
     kFp8DynamicTensorSym: get_ops().dynamic_scaled_fp8_quant.default,  # noqa: E501
     kFp8DynamicTokenSym: get_ops().dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
-if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+if current_platform.is_cuda() and has_op("scaled_fp4_quant"):
     QUANT_OPS[kNvfp4Quant] = get_ops().scaled_fp4_quant.default
 if current_platform.is_cuda():
     QUANT_OPS[kFp8Dynamic128Sym] = get_ops().per_token_group_fp8_quant.default  # noqa: E501

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 import torch
+from vllm._ops_dispatch import has_op
 import torch._inductor.pattern_matcher as pm
 from torch import fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -330,7 +331,7 @@ class AttnFusionPass(VllmPatternMatcherPass):
             )
             pattern_fp8.register_if_supported(self.patterns)
 
-            if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+            if current_platform.is_cuda() and has_op("scaled_fp4_quant"):
                 pattern_nvfp4 = AttentionNvfp4QuantPattern(
                     layer, config.model_config.dtype
                 )

--- a/vllm/compilation/matcher_utils.py
+++ b/vllm/compilation/matcher_utils.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 from torch._higher_order_ops import auto_functionalized
 from torch._ops import OpOverload
 
@@ -35,7 +35,7 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
     kFp8DynamicTokenSym: get_ops().dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
 
-if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+if current_platform.is_cuda() and has_op("scaled_fp4_quant"):
     QUANT_OPS[kNvfp4Quant] = get_ops().scaled_fp4_quant.default  # noqa: E501
 
 if current_platform.is_cuda():

--- a/vllm/compilation/matcher_utils.py
+++ b/vllm/compilation/matcher_utils.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch._higher_order_ops import auto_functionalized
 from torch._ops import OpOverload
 
@@ -23,25 +24,25 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.platforms import current_platform
 
-RMS_OP = torch.ops._C.rms_norm.default
-RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
-ROTARY_OP = torch.ops._C.rotary_embedding.default
+RMS_OP = get_ops().rms_norm.default
+RMS_ADD_OP = get_ops().fused_add_rms_norm.default
+ROTARY_OP = get_ops().rotary_embedding.default
 FLASHINFER_ROTARY_OP = torch.ops.vllm.flashinfer_rotary_embedding.default
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {
-    kFp8StaticTensorSym: torch.ops._C.static_scaled_fp8_quant.default,  # noqa: E501
-    kFp8DynamicTensorSym: torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa: E501
-    kFp8DynamicTokenSym: torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
+    kFp8StaticTensorSym: get_ops().static_scaled_fp8_quant.default,  # noqa: E501
+    kFp8DynamicTensorSym: get_ops().dynamic_scaled_fp8_quant.default,  # noqa: E501
+    kFp8DynamicTokenSym: get_ops().dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
 
 if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
-    QUANT_OPS[kNvfp4Quant] = torch.ops._C.scaled_fp4_quant.default  # noqa: E501
+    QUANT_OPS[kNvfp4Quant] = get_ops().scaled_fp4_quant.default  # noqa: E501
 
 if current_platform.is_cuda():
-    QUANT_OPS[kFp8Dynamic128Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
-    QUANT_OPS[kFp8Dynamic64Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
+    QUANT_OPS[kFp8Dynamic128Sym] = get_ops().per_token_group_fp8_quant.default  # noqa: E501
+    QUANT_OPS[kFp8Dynamic64Sym] = get_ops().per_token_group_fp8_quant.default  # noqa: E501
 
-SILU_MUL_OP = torch.ops._C.silu_and_mul.default
+SILU_MUL_OP = get_ops().silu_and_mul.default
 
 
 class MatcherCustomOp(ABC):

--- a/vllm/compilation/qk_norm_rope_fusion.py
+++ b/vllm/compilation/qk_norm_rope_fusion.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 
 import torch
+from vllm._ops_dispatch import get_ops
 import torch._inductor.pattern_matcher as pm
 from torch import fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -21,7 +22,7 @@ from .vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
 
 logger = init_logger(__name__)
 
-FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default
+FUSED_QK_ROPE_OP = get_ops().fused_qk_norm_rope.default
 
 
 class QkNormRopePattern:

--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -5,7 +5,7 @@ import os
 from typing import Any
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 from torch.distributed import ProcessGroup
 
 from vllm.distributed.utils import pickle
@@ -28,7 +28,7 @@ class CpuCommunicator(DeviceCommunicatorBase):
 
         if (
             (current_platform.get_cpu_architecture() == CpuArchEnum.X86)
-            and hasattr(torch.ops._C, "init_shm_manager")
+            and has_op("init_shm_manager")
             and (unique_name.startswith("tp") or unique_name.startswith("pp"))
         ):
             self.dist_module = _CPUSHMDistributed(self)

--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch.distributed import ProcessGroup
 
 from vllm.distributed.utils import pickle
@@ -125,13 +126,13 @@ class _CPUSHMDistributed:
         self.handle = self._init_cpu_shm()
 
     def _init_cpu_shm(self) -> int:
-        handle = torch.ops._C.init_shm_manager(
+        handle = get_ops().init_shm_manager(
             self.group_name,
             self.communicator.world_size,
             self.communicator.rank,
         )
         torch.distributed.barrier(self.communicator.device_group)
-        torch.ops._C.join_shm_manager(
+        get_ops().join_shm_manager(
             handle,
             self.group_name,
         )
@@ -142,7 +143,7 @@ class _CPUSHMDistributed:
     def all_reduce(
         self, input: torch.Tensor, group: ProcessGroup | None = None
     ) -> None:
-        torch.ops._C.shm_allreduce(self.handle, input)
+        get_ops().shm_allreduce(self.handle, input)
 
     def gather(
         self,
@@ -152,7 +153,7 @@ class _CPUSHMDistributed:
         group: ProcessGroup | None = None,
     ) -> None:
         # Note: different from the torch gather, here we use local dst rank.
-        torch.ops._C.shm_gather(
+        get_ops().shm_gather(
             self.handle,
             input,
             gather_list,
@@ -165,7 +166,7 @@ class _CPUSHMDistributed:
         input: torch.Tensor,
         group: ProcessGroup | None = None,
     ) -> None:
-        torch.ops._C.shm_all_gather(self.handle, input, output)
+        get_ops().shm_all_gather(self.handle, input, output)
 
     def send_tensor_dict(
         self,
@@ -184,7 +185,7 @@ class _CPUSHMDistributed:
         )
         value_list.append(key_size_tensor)
 
-        torch.ops._C.shm_send_tensor_list(self.handle, value_list, dst)
+        get_ops().shm_send_tensor_list(self.handle, value_list, dst)
 
         return None
 
@@ -192,7 +193,7 @@ class _CPUSHMDistributed:
         self,
         src: int,
     ) -> dict[str, torch.Tensor | Any]:
-        tensor_list = torch.ops._C.shm_recv_tensor_list(self.handle, src)
+        tensor_list = get_ops().shm_recv_tensor_list(self.handle, src)
 
         value_list: list[torch.Tensor] = tensor_list[:-1]
         key_size_tensor = tensor_list[-1]

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -43,6 +43,7 @@ import torch.distributed._symmetric_memory
 from torch.distributed import Backend, ProcessGroup
 
 import vllm.envs as envs
+from vllm._ops_dispatch import has_op
 from vllm.distributed.device_communicators.base_device_communicator import (
     DeviceCommunicatorBase,
 )
@@ -382,8 +383,8 @@ class GroupCoordinator:
             current_platform.is_cuda_alike() or current_platform.is_tpu()
         )
 
-        self.use_cpu_custom_send_recv = current_platform.is_cpu() and hasattr(
-            torch.ops._C, "init_shm_manager"
+        self.use_cpu_custom_send_recv = current_platform.is_cpu() and has_op(
+            "init_shm_manager"
         )
 
     def create_mq_broadcaster(

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -15,6 +15,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
+from vllm._ops_dispatch import get_ops
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils.collection_utils import LazyDict
@@ -39,7 +40,7 @@ class FatreluAndMul(CustomOp):
         super().__init__()
         self.threshold = threshold
         if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.fatrelu_and_mul
+            self.op = get_ops().fatrelu_and_mul
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
 
@@ -72,7 +73,7 @@ class SiluAndMul(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.silu_and_mul
+            self.op = get_ops().silu_and_mul
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
 
@@ -115,7 +116,7 @@ class MulAndSilu(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.mul_and_silu
+            self.op = get_ops().mul_and_silu
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
 
@@ -213,9 +214,9 @@ class GeluAndMul(CustomOp):
             raise ValueError(f"Unknown approximate mode: {approximate}")
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
             if approximate == "none":
-                self.op = torch.ops._C.gelu_and_mul
+                self.op = get_ops().gelu_and_mul
             elif approximate == "tanh":
-                self.op = torch.ops._C.gelu_tanh_and_mul
+                self.op = get_ops().gelu_tanh_and_mul
         if current_platform.is_rocm() and approximate == "tanh":
             logger.warning_once(
                 "[ROCm] PyTorch's native GELU with tanh approximation is unstable "
@@ -279,7 +280,7 @@ class SwigluOAIAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        torch.ops._C.swigluoai_and_mul(out, x, self.alpha, self.limit)
+        get_ops().swigluoai_and_mul(out, x, self.alpha, self.limit)
         return out
 
     def extra_repr(self) -> str:
@@ -291,7 +292,7 @@ class NewGELU(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
-            self.op = torch.ops._C.gelu_new
+            self.op = get_ops().gelu_new
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
 
@@ -316,7 +317,7 @@ class FastGELU(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
-            self.op = torch.ops._C.gelu_fast
+            self.op = get_ops().gelu_fast
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
 
@@ -341,7 +342,7 @@ class QuickGELU(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
-            self.op = torch.ops._C.gelu_quick
+            self.op = get_ops().gelu_quick
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
 

--- a/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batched_deep_gemm_moe.py
@@ -3,6 +3,7 @@
 
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.forward_context import get_forward_context, is_forward_context_available
@@ -200,7 +201,7 @@ def persistent_masked_m_silu_mul_quant(
     ).to_int()
 
     if cuda_arch >= 80:
-        torch.ops._C.persistent_masked_m_silu_mul_quant(
+        get_ops().persistent_masked_m_silu_mul_quant(
             y, tokens_per_expert, y_q, y_s, ceil_ue8m0
         )
     else:

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -4,6 +4,7 @@ import weakref
 from collections.abc import Callable
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch.nn import functional as F
 
 from vllm import _custom_ops as ops
@@ -163,7 +164,7 @@ class SGLFusedMOE:
             e_score_correction_bias=e_score_correction_bias,
         )
 
-        torch.ops._C.fused_experts_cpu(
+        get_ops().fused_experts_cpu(
             x,
             layer.w13_weight,
             layer.w2_weight,

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -4,7 +4,7 @@ import weakref
 from collections.abc import Callable
 
 import torch
-from vllm._ops_dispatch import get_ops
+from vllm._ops_dispatch import get_ops, has_op
 from torch.nn import functional as F
 
 from vllm import _custom_ops as ops
@@ -243,7 +243,7 @@ class CPUFusedMOE:
         self,
         layer: torch.nn.Module,
     ) -> tuple[bool, str]:
-        if not hasattr(torch.ops._C, "prepack_moe_weight"):
+        if not has_op("prepack_moe_weight"):
             return False, "none"
 
         dtype = layer.w13_weight.dtype

--- a/vllm/model_executor/layers/fused_moe/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cutlass_moe.py
@@ -5,6 +5,7 @@
 from collections.abc import Callable
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import _custom_ops as ops
@@ -691,7 +692,7 @@ def run_cutlass_moe_fp4(
         blockscale_offsets[:-1],
     )
     del rep_a_fp4, rep_a_blockscale
-    torch.ops._C.silu_and_mul(c2, c1)
+    get_ops().silu_and_mul(c2, c1)
     int_fp4, int_blockscale = ops.scaled_fp4_experts_quant(
         c2, a2_gscale, expert_offsets, blockscale_offsets, num_topk
     )
@@ -1031,7 +1032,7 @@ def run_cutlass_block_scaled_fused_experts(
     )
 
     intermediate = torch.empty((m * topk, n), dtype=out_dtype, device=device)
-    torch.ops._C.silu_and_mul(intermediate, c1)
+    get_ops().silu_and_mul(intermediate, c1)
 
     intermediate_q, a2_scale = _fp8_quantize(
         intermediate, A_scale=None, per_act_token=False, block_shape=[128, 128]

--- a/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
@@ -5,6 +5,7 @@
 from collections.abc import Callable
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 import vllm._custom_ops as ops
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -33,10 +34,10 @@ def default_activation_func(
     activation: str, output: torch.Tensor, input: torch.Tensor
 ) -> None:
     if activation == "silu":
-        torch.ops._C.silu_and_mul(output, input)
+        get_ops().silu_and_mul(output, input)
     elif activation == "swigluoai":
         # alpha = 1.702, limit = 7.0
-        torch.ops._C.swigluoai_and_mul(output, input)
+        get_ops().swigluoai_and_mul(output, input)
     else:
         raise ValueError(
             f"Unsupported activation: {activation}. "

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import Any
 
 import torch
+from vllm._ops_dispatch import get_ops
 import torch.nn.functional as F
 
 import vllm.envs as envs
@@ -2015,16 +2016,16 @@ def fused_experts_impl(
 
         # Activation function with multiplication
         if activation == "silu":
-            torch.ops._C.silu_and_mul(
+            get_ops().silu_and_mul(
                 intermediate_cache2, intermediate_cache1.view(-1, N)
             )
         elif activation == "gelu":
-            torch.ops._C.gelu_and_mul(
+            get_ops().gelu_and_mul(
                 intermediate_cache2, intermediate_cache1.view(-1, N)
             )
         elif activation == "swigluoai":
             # alpha = 1.702, limit = 7.0
-            torch.ops._C.swigluoai_and_mul(
+            get_ops().swigluoai_and_mul(
                 intermediate_cache2, intermediate_cache1.view(-1, N)
             )
         # Activation function without multiplication

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -8,6 +8,7 @@ from math import prod
 from typing import final
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 import vllm.envs as envs
 from vllm.forward_context import get_forward_context, is_forward_context_available
@@ -578,12 +579,12 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
     ) -> None:
         assert output.size(-1) * 2 == input.size(-1)
         if activation == "silu":
-            torch.ops._C.silu_and_mul(output, input)
+            get_ops().silu_and_mul(output, input)
         elif activation == "gelu":
-            torch.ops._C.gelu_and_mul(output, input)
+            get_ops().gelu_and_mul(output, input)
         elif activation == "swigluoai":
             # alpha = 1.702, limit = 7.0
-            torch.ops._C.swigluoai_and_mul(output, input)
+            get_ops().swigluoai_and_mul(output, input)
         else:
             raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -3,6 +3,7 @@
 
 
 import torch
+from vllm._ops_dispatch import get_ops
 import torch.nn.functional as F
 
 import vllm.envs as envs
@@ -249,13 +250,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                     and check_cpu_sgl_kernel(n_w13, k_w13, dtype_w13)
                     and check_cpu_sgl_kernel(n_w2, k_w2, dtype_w2)
                 ):
-                    packed_w13_weight = torch.ops._C.convert_weight_packed(
+                    packed_w13_weight = get_ops().convert_weight_packed(
                         layer.w13_weight
                     )
                     assert packed_w13_weight.size() == layer.w13_weight.size()
                     layer.w13_weight.copy_(packed_w13_weight)
                     del packed_w13_weight
-                    packed_w2_weight = torch.ops._C.convert_weight_packed(
+                    packed_w2_weight = get_ops().convert_weight_packed(
                         layer.w2_weight
                     )
                     assert packed_w2_weight.size() == layer.w2_weight.size()

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -5,6 +5,7 @@ import enum
 from enum import Enum
 
 import torch
+from vllm._ops_dispatch import get_ops
 from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import (
     ActivationOrdering,
@@ -2316,7 +2317,7 @@ class CompressedTensorsW4A8Int8MoEMethod(CompressedTensorsMoEMethod):
             renormalize=layer.renormalize,
         )
 
-        return torch.ops._C.dynamic_4bit_int_moe(
+        return get_ops().dynamic_4bit_int_moe(
             x,
             topk_ids.to(torch.long),
             topk_weights,

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 
 import gguf
 import torch
+from vllm._ops_dispatch import get_ops
 from gguf import GGMLQuantizationType as WeightType
 from torch.nn.parameter import Parameter, UninitializedParameter
 
@@ -248,9 +249,9 @@ def _fused_moe_gguf(
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
         if activation == "silu":
-            torch.ops._C.silu_and_mul(out, x)
+            get_ops().silu_and_mul(out, x)
         elif activation == "gelu":
-            torch.ops._C.gelu_and_mul(out, x)
+            get_ops().gelu_and_mul(out, x)
         else:
             raise ValueError(f"Unsupported activation: {activation}")
         return out

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
@@ -3,6 +3,7 @@
 
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 from vllm import _custom_ops as ops
 from vllm import envs
@@ -142,7 +143,7 @@ class CPUScaledMMLinearKernel(ScaledMMLinearKernel):
     def process_weights_for_sgl(self, layer: torch.nn.Module) -> None:
         # WEIGHT
         weight = getattr(layer, self.w_q_name)
-        packed_weight = torch.ops._C.convert_weight_packed(weight)
+        packed_weight = get_ops().convert_weight_packed(weight)
         replace_parameter(
             layer, self.w_q_name, torch.nn.Parameter(packed_weight, requires_grad=False)
         )
@@ -210,7 +211,7 @@ class CPUScaledMMLinearKernel(ScaledMMLinearKernel):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         w_q, w_s, _, _, _ = self._get_weight_params(layer)
-        return torch.ops._C.int8_scaled_mm_with_quant(
+        return get_ops().int8_scaled_mm_with_quant(
             x,
             w_q,
             w_s,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
@@ -785,7 +786,7 @@ def per_token_group_quant_fp8(
     # prefer CUDA kernel if available
     # TODO(bnell): this causes some fp8 moe test to fail.
     if current_platform.is_cuda() and x.is_contiguous():
-        torch.ops._C.per_token_group_fp8_quant(
+        get_ops().per_token_group_fp8_quant(
             x, x_q, x_s, group_size, eps, fp8_min, fp8_max, use_ue8m0
         )
         return x_q, x_s
@@ -893,7 +894,7 @@ def per_token_group_quant_fp8_packed_for_deepgemm(
     else:
         x_q_local = torch.empty_like(x_contiguous, device=x.device, dtype=dtype)
 
-    torch.ops._C.per_token_group_fp8_quant_packed(
+    get_ops().per_token_group_fp8_quant_packed(
         x_contiguous,
         x_q_local,
         x_s_packed,

--- a/vllm/model_executor/layers/quantization/utils/int8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/int8_utils.py
@@ -9,6 +9,7 @@ import os
 from typing import Any
 
 import torch
+from vllm._ops_dispatch import get_ops
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -227,7 +228,7 @@ def per_token_group_quant_int8(
     )
     # prefer CUDA kernel if available
     if current_platform.is_cuda():
-        torch.ops._C.per_token_group_quant_int8(
+        get_ops().per_token_group_quant_int8(
             x, x_q, x_s, group_size, eps, float(int8_min), float(int8_max)
         )
         return x_q, x_s

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -8,6 +8,7 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm import envs
+from vllm._ops_dispatch import get_ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
@@ -199,12 +200,12 @@ def dispatch_cpu_unquantized_gemm(
     N, K = layer.weight.size()
     dtype = layer.weight.dtype
     if envs.VLLM_CPU_SGL_KERNEL and check_cpu_sgl_kernel(N, K, dtype):
-        packed_weight = torch.ops._C.convert_weight_packed(layer.weight)
+        packed_weight = get_ops().convert_weight_packed(layer.weight)
         if getattr(layer, "bias", None) is not None:
             bias_f32 = layer.bias.to(torch.float32)
         else:
             bias_f32 = None
-        layer.cpu_linear = lambda x, weight, bias: torch.ops._C.weight_packed_linear(
+        layer.cpu_linear = lambda x, weight, bias: get_ops().weight_packed_linear(
             x, packed_weight, bias_f32 if bias is not None else None, True
         )
         if remove_weight:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -29,6 +29,7 @@ from collections.abc import Callable, Iterable
 from itertools import islice
 
 import torch
+from vllm._ops_dispatch import get_ops
 from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 
@@ -693,7 +694,7 @@ def sparse_attn_indexer(
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
-            torch.ops._C.top_k_per_row_prefill(
+            get_ops().top_k_per_row_prefill(
                 logits,
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,
@@ -746,7 +747,7 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_decode_tokens, :topk_tokens]
 
-        torch.ops._C.top_k_per_row_decode(
+        get_ops().top_k_per_row_decode(
             logits,
             next_n,
             decode_metadata.seq_lens,

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import numpy as np
 import numpy.typing as npt
 import torch
+from vllm._ops_dispatch import get_ops
 from packaging import version
 from packaging.version import Version
 from torch.library import Library, infer_schema
@@ -557,7 +558,7 @@ def weak_ref_tensor(tensor: Any) -> Any:
     but will not keep the original tensor alive.
     """
     if isinstance(tensor, torch.Tensor):
-        return torch.ops._C.weak_ref_tensor(tensor)
+        return get_ops().weak_ref_tensor(tensor)
     else:
         return tensor
 
@@ -595,7 +596,7 @@ def get_cuda_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
     Get a CUDA view of a CPU tensor using Unified Virtual Addressing (UVA).
     """
     assert cpu_tensor.is_pinned(), "CPU tensor must be pinned"
-    return torch.ops._C.get_cuda_view_from_cpu_tensor(cpu_tensor)
+    return get_ops().get_cuda_view_from_cpu_tensor(cpu_tensor)
 
 
 # Helper function used in testing.

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 
 from vllm import envs
+from vllm._ops_dispatch import get_utils
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.utils import set_random_seed
@@ -81,12 +82,8 @@ class CPUWorker(Worker):
             self.local_omp_cpuid = omp_cpuids_list[self.rank]
 
         if self.local_omp_cpuid != "nobind":
-            try:
-                ret = torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
-            except Exception:  # FIXME: hack to get this working for non-AVX2 builds.
-                ret = torch.ops._C_avx512_utils.init_cpu_threads_env(
-                    self.local_omp_cpuid
-                )
+            # Use dispatcher to route to correct utils module (_C_utils or _C_avx512_utils)
+            ret = get_utils().init_cpu_threads_env(self.local_omp_cpuid)
             if ret:
                 logger.info(ret)
 


### PR DESCRIPTION
## Summary

This PR fixes the namespace mismatch issue that causes both AVX2 and AVX512 paths to crash during inference.

**Root Cause:** The two extensions register to different namespaces:
- `_C.so` (AVX2) registers → `torch.ops._C.*`
- `_C_avx512.so` (AVX512) registers → `torch.ops._C_avx512.*`

But vLLM Python code hardcodes calls to `torch.ops._C.something()`, which fails when the AVX512 extension is loaded (and vice versa).

## Changes

| File | Changes |
|------|---------|
| `vllm/_ops_dispatch.py` | **NEW** - Dispatcher module with `get_ops()`, `get_utils()`, `has_op()` |
| `vllm/_custom_ops.py` | Updated 83 `torch.ops._C.` → `get_ops().`, 13 `hasattr` → `has_op()` |
| `vllm/v1/worker/cpu_worker.py` | Replaced try/except hack with `get_utils()` |
| `docs/runtime-isa-dispatch.md` | Full documentation and implementation guide |

## How It Works

```python
# _ops_dispatch.py detects which extension is loaded
def get_ops():
    if hasattr(torch.ops._C_avx512, 'silu_and_mul'):
        return torch.ops._C_avx512
    return torch.ops._C

# Call sites now use dispatcher
get_ops().silu_and_mul(out, x)  # Routes to correct extension
```

## Testing Checklist

- [ ] AVX2 system: `import vllm` succeeds
- [ ] AVX2 system: `LLM("facebook/opt-125m")` loads
- [ ] AVX2 system: `llm.generate("Hello")` completes
- [ ] AVX512 system: `import vllm` succeeds
- [ ] AVX512 system: `LLM("facebook/opt-125m")` loads
- [ ] AVX512 system: `llm.generate("Hello")` completes

## Test Command

```bash
python -c "
from vllm._ops_dispatch import _detect_cpu_extension
print(f'Detected extension: {_detect_cpu_extension()}')

from vllm import LLM
llm = LLM('facebook/opt-125m')
print(llm.generate('Hello'))
"
```